### PR TITLE
Handling corner cases of MSI enabled with MSI address zero

### DIFF
--- a/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
+++ b/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
@@ -74,7 +74,7 @@ disclaimer.
 *
 *******************************************************************************/
 #define MV_DRV_NAME     "mvDmaDrv"
-#define MV_DRV_NAME_VERSION "1.37"
+#define MV_DRV_NAME_VERSION "1.38"
 #define MV_DRV_MAJOR	244
 #define MV_DRV_MINOR	3
 #define MV_DRV_FOPS	mvDmaDrv_fops
@@ -165,8 +165,10 @@ disclaimer.
 
 #define DFX_SOFT_RST_BITS (MG_SOFT_RST_TRIGGER_BIT | TABLE_START_INIT_BIT)
 
-#define SECS_DELAY_WQ 2
+#define SECS_DELAY_WQ 1
+#define MAX_MAP_RETRIES 3
 
+#define DEBUG
 #include "mvDriverTemplate.h"
 
 #include <linux/delay.h>
@@ -218,6 +220,7 @@ struct dma_mapping {
 #endif
 	size_t size;
 	loff_t pci_offset;
+	int retries_cnt;
 	struct pci_dev *pdev;
 	struct device *dev;
 	/* First index to array is the Packet Processor unit number, Second is the PCIe bar (0/2/4) */
@@ -265,7 +268,7 @@ static int mvDmaDrv_mmap(struct file *file, struct vm_area_struct *vma)
 	/* Until LK 4.11, dma_alloc_coherent(NULL, ...) is allowed, and used in
 	   case of AC3 */
 	if (!m->dev && !platdrv_dev) {
-		printk(KERN_ERR "%s: Nither PCI, nor Platform device is registered, cannot mmap\n",
+		pr_err(KERN_ERR "%s: Neither PCI, nor Platform device is registered, cannot mmap\n",
 		       MV_DRV_NAME);
 		return -EIO;
 	}
@@ -458,52 +461,52 @@ static int mvDmaDrv_PollIRQStats(void __iomem *base)
  
 	/* Clear on Read registers: */
  val = readl(base + MG_RX_SDMA_INT_CAUSE0);
- pr_info("%s: reg %x = %x\n", __func__, MG_RX_SDMA_INT_CAUSE0, val);
+ pr_debug("%s: reg %x = %x\n", __func__, MG_RX_SDMA_INT_CAUSE0, val);
 
  val = readl(base + MG_TX_SDMA_INT_CAUSE0);
- pr_info("%s: reg %x = %x\n", __func__,  MG_TX_SDMA_INT_CAUSE0, val);
+ pr_debug("%s: reg %x = %x\n", __func__,  MG_TX_SDMA_INT_CAUSE0, val);
 
  val = readl(base + MG_RX_SDMA_INT_CAUSE1);
- pr_info("%s: reg %x = %x\n", __func__,  MG_RX_SDMA_INT_CAUSE1, val);
+ pr_debug("%s: reg %x = %x\n", __func__,  MG_RX_SDMA_INT_CAUSE1, val);
 
  val = readl(base + MG_RX_SDMA_INT_CAUSE2);
- pr_info("%s: reg %x = %x\n", __func__,  MG_RX_SDMA_INT_CAUSE2, val);
+ pr_debug("%s: reg %x = %x\n", __func__,  MG_RX_SDMA_INT_CAUSE2, val);
 
  val = readl(base + MG_TX_SDMA_INT_CAUSE1);
- pr_info("%s: reg %x = %x\n",  __func__, MG_TX_SDMA_INT_CAUSE1, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_TX_SDMA_INT_CAUSE1, val);
 
  val = readl(base + MG_TX_SDMA_INT_CAUSE2);
- pr_info("%s: reg %x = %x\n",  __func__, MG_TX_SDMA_INT_CAUSE2, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_TX_SDMA_INT_CAUSE2, val);
 
  /* Clear on Write cause registers: */
  val = readl(base + MG_INT_IRQ_CAUSE);
- pr_info("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE, val);
  writel(0, base + MG_INT_IRQ_CAUSE);
 
  val = readl(base + MG1_INT_IRQ_CAUSE1);
- pr_info("%s: reg %x = %x\n",  __func__, MG1_INT_IRQ_CAUSE1, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG1_INT_IRQ_CAUSE1, val);
  writel(0, base + MG1_INT_IRQ_CAUSE1);
 
  val = readl(base + MG_INT_IRQ_CAUSE3);
- pr_info("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE3, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE3, val);
  writel(0, base + MG_INT_IRQ_CAUSE3);
 
  val = readl(base + MG_INT_IRQ_CAUSE1);
- pr_info("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE1, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE1, val);
  writel(0, base + MG_INT_IRQ_CAUSE1);
 
  val = readl(base + MG_INT_IRQ_CAUSE2);
- pr_info("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE2, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_INT_IRQ_CAUSE2, val);
  writel(0, base + MG_INT_IRQ_CAUSE2);
 
  val = readl(base + MGCAM_BAD_ADDR);
- pr_info("%s: reg %x = %x\n",  __func__, MGCAM_BAD_ADDR, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MGCAM_BAD_ADDR, val);
 
  val = readl(base + MG_UEA);
- pr_info("%s: reg %x = %x\n",  __func__, MG_UEA, val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_UEA, val);
 
  val = readl(base + MG_CM3_SRAM_OOR_ADDR );
- pr_info("%s: reg %x = %x\n",  __func__, MG_CM3_SRAM_OOR_ADDR , val);
+ pr_debug("%s: reg %x = %x\n",  __func__, MG_CM3_SRAM_OOR_ADDR , val);
 
  return 0;
 }
@@ -560,7 +563,7 @@ static int mvDmaDrv_do_CPSS_skip_sequence_pcie(void __iomem *base)
 static int mvDmaDrv_stopAndResetSDMA_AC3X_Aldrin_PP(struct dma_mapping *m)
 {
  struct pci_dev *pdev;
- int err, i, ii;
+ int err = 0, i, ii;
  u16 cmd16;
  u32 val;
  loff_t off;
@@ -571,7 +574,7 @@ static int mvDmaDrv_stopAndResetSDMA_AC3X_Aldrin_PP(struct dma_mapping *m)
  udelay(1750);
 
  if (!m->dev) {
-	pr_info("%s: No PCI device assigned!\n", __func__);
+	pr_err("%s: No PCI device assigned\n", __func__);
 	return -ENOENT;
  	}
 
@@ -581,42 +584,50 @@ static int mvDmaDrv_stopAndResetSDMA_AC3X_Aldrin_PP(struct dma_mapping *m)
 	 bus = (off >> 8) & 0xff;
 	 devfn = PCI_DEVFN(((off >> 3) & 0x1f), (off & 0x07));
 
-	 pr_info("%s: device %d: before pci_get_domain_bus_and_slot()!\n", __func__, i);
+	 pr_debug("%s: device %d: before pci_get_domain_bus_and_slot()\n", __func__, i);
 	 pdev = pci_get_domain_bus_and_slot(domain, bus + i, devfn);
-	 pr_info("%s: device %d: after pci_get_domain_bus_and_slot()!\n", __func__, i);
+	 pr_debug("%s: device %d: after pci_get_domain_bus_and_slot()\n", __func__, i);
 	 
 	 if (!pdev) {
-		pr_info("%s: Failed to get PCI device %x:%x:%x.%x\n", __func__, domain, bus + i, (unsigned)((off >> 3) & 0x1f), (unsigned)(off & 0x07));
+		pr_err("%s: Failed to get PCI device %x:%x:%x.%x\n", __func__, domain, bus + i, (unsigned)((off >> 3) & 0x1f), (unsigned)(off & 0x07));
 		continue;
 	 	}
 
 	 m->pdevs_list[i] = pdev;
 	 err = pcim_enable_device(pdev);
-	 pr_info("%s: device %d: after pcim_enable_device()!\n", __func__, i);
+	 pr_debug("%s: device %d: after pcim_enable_device()\n", __func__, i);
 	 
 	 if (err) {
-		pr_info("%s: pcim enable device failed err %d!\n",__func__,err);
+		pr_err("%s: pcim enable device failed err %d\n",__func__,err);
 		return err;
 	 }
+
+		pr_debug("%s: device %d: before writing register at line %d\n", __func__, i, __LINE__);
+		pci_read_config_word(pdev, PCI_COMMAND, &cmd16);
+		pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+		
+		cmd16 = cmd16 & ~PCI_COMMAND_MASTER;
+		pci_write_config_word(pdev, PCI_COMMAND, cmd16);
+		pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
 		
 		m->base[i][0] = pcim_iomap(pdev, 0, 1*1024*1024); /* CnM registers/MG 64M AC3X/BC2/Aldrin only*/
 	 	if (m->base[i][0]) {
 				val = readl(m->base[i][0] + CNM_PCIE_WIN0_CTRL_REG);
 				if (!(val & PCIE_ADDR_WIN_CTRL_SZ_EN_MASK)) {
-						pr_err("%s: device %d, PCI BAR #2 is not enabled!\n", __func__, i);
+						pr_err("%s: device %d, PCI BAR #2 is not enabled\n", __func__, i);
 						continue;
 					}
 	 		}
 			 else {
-					pr_err("%s: device %d, BAR #0 is not mappable!\n", __func__, i);
-					continue;
+					pr_err("%s: device %d, BAR #0 is not mappable\n", __func__, i);
+					return -EAGAIN;
 			 	}
 
         if (!err){
-				pr_info("%s: device %d: before pcim_iomap()!\n", __func__, i);
-                m->base[i][2] = pcim_iomap(pdev, 2, 64*1024*1024); /* switching registers/MG 64M AC3X/BC2/Aldrin only*/
-				pr_info("%s: device %d: after pcim_iomap()!\n", __func__, i);
-               if (m->base[i][2]) {
+				pr_debug("%s: device %d: before pcim_iomap()\n", __func__, i);
+				m->base[i][2] = pcim_iomap(pdev, 2, 64*1024*1024); /* switching registers/MG 64M AC3X/BC2/Aldrin only*/
+				pr_debug("%s: device %d: after pcim_iomap()\n", __func__, i);
+               	if (m->base[i][2]) {
                        /* 
                         * Write Receive SDMA Queue Command Register in MG with stop all RX queues Values
                         * This will disable all of the SDMA RX reception.
@@ -627,66 +638,60 @@ static int mvDmaDrv_stopAndResetSDMA_AC3X_Aldrin_PP(struct dma_mapping *m)
                         * state without having the RX DMA running unsupervised.
                         */
 
-						pr_info("%s: device %d: before writing registers!\n", __func__, i);
+						pr_debug("%s: device %d: before writing registers\n", __func__, i);
 						/* disable retries on resource error */
 						writel(RX_SDMA_ERR_MOD, m->base[i][2] + MG_RX_SDMA_RES_ERR_MOD01);
-			   			pr_info("%s: device %d: after writing 1st register!\n", __func__, i);
+			   			pr_debug("%s: device %d: after writing 1st register\n", __func__, i);
 						writel(RX_SDMA_ERR_MOD, m->base[i][2] + MG_RX_SDMA_RES_ERR_MOD01 + 0x4);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
 						for (ii=0; ii<6; ii++)
 							writel(RX_SDMA_ERR_MOD, m->base[i][2] + MG_RX_SDMA_RES_ERR_MOD27 + (0x4 * ii));
-						 pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
+						 pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
 						 /* Stop SDMA RX - prevent writing on memory which will be released to kernel */
 						writel(STOP_ALL_Q_BITS, m->base[i][2] + MG_RX_SDMA_Q_CMD_REG);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
 			   			/* Stop SDMA TX - descriptor writeback might corrupt memory */
-			   		   writel(STOP_ALL_Q_BITS, m->base[i][2] + MG_TX_SDMA_Q_CMD_REG);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-						msleep(10);
+			   			writel(STOP_ALL_Q_BITS, m->base[i][2] + MG_TX_SDMA_Q_CMD_REG);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+						
 						/* Stop FDB AU messages to CPU (FDB unit) */
 
 						/* Stop AU messages on MG (DMA) */
-					   writel(STOP_AU_Q_BIT, m->base[i][2] + MG_AU_Q_HOST_CONF_REG);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-						msleep(10);
+						writel(STOP_AU_Q_BIT, m->base[i][2] + MG_AU_Q_HOST_CONF_REG);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+						
 						/* Reset AU+FU queue counters (reset queue) on MG (DMA) */
-					   writel(RESET_AU_Q_CNTRS_BITS | STOP_AU_Q_BIT, m->base[i][2] + MG_AU_Q_HOST_CONF_REG);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-						msleep(10);
-					   mb();
+						writel(RESET_AU_Q_CNTRS_BITS | STOP_AU_Q_BIT, m->base[i][2] + MG_AU_Q_HOST_CONF_REG);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+						
+						mb();
 
 						/* Finally, completely reset SDMA: */
 						val = readl(m->base[i][2] + MG_EXT_GLOBAL_CNTRL_REG);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-						msleep(10);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+						
 						val |= SDMA_SW_RST_BIT;
 						
 						writel(val, m->base[i][2] + MG_EXT_GLOBAL_CNTRL_REG);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-						msleep(10);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+						
 						mb();
 					    val &= ~SDMA_SW_RST_BIT;
 			   
 					    writel(val, m->base[i][2] + MG_EXT_GLOBAL_CNTRL_REG);
-						pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-						msleep(10);
+						pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+						
 						mb();
 
 			   			pr_info("%s: Stopped DMA on PCI device %x:%x:%x.%x\n", __func__, domain, bus + i, (unsigned)((off >> 3) & 0x1f), (unsigned)(off & 0x07));
 
                }
-	       else pr_info("%s: base %d BAR2 not mappable!\n", __func__, i);
+	       else pr_err("%s: base %d BAR2 not mappable\n", __func__, i);
 
-				pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-				pci_read_config_word(pdev, PCI_COMMAND, &cmd16);
-		   		pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-				msleep(10);
-				cmd16 = cmd16 & ~PCI_COMMAND_MASTER;
-				pci_write_config_word(pdev, PCI_COMMAND, cmd16);
-				pr_info("%s: device %d: after writing register at line %d!\n", __func__, i, __LINE__);
-				msleep(10);
+				pr_debug("%s: device %d: after writing register at line %d\n", __func__, i, __LINE__);
+				
         }
-	else pr_info("%s: unable to iomap %d. err %d!", __func__, i, err);
+	else pr_err("%s: unable to iomap %d. err %d!", __func__, i, err);
  	}
 
 	udelay(20);
@@ -698,7 +703,7 @@ static int mvDmaDrv_stopAndResetSDMA_AC3X_Aldrin_PP(struct dma_mapping *m)
 
 static int mvDmaDrv_DoReset(struct dma_mapping *m, int conditional_reset)
 {
-	int i, err;
+	int i, err = 0;
 	loff_t off;
 	int domain;
 	unsigned int bus;
@@ -717,12 +722,12 @@ static int mvDmaDrv_DoReset(struct dma_mapping *m, int conditional_reset)
 		pdev = pci_get_domain_bus_and_slot(domain, bus + i, devfn);
 	
 		if (!pdev) {
-		   pr_info("%s: Failed to get PCI device %x:%x:%x.%x\n", __func__, domain, bus + i, (unsigned)((off >> 3) & 0x1f), (unsigned)(off & 0x07));
+		   pr_err("%s: Failed to get PCI device %x:%x:%x.%x\n", __func__, domain, bus + i, (unsigned)((off >> 3) & 0x1f), (unsigned)(off & 0x07));
 		   continue;
 		   }
 
 		if (!pdev) {
-		   pr_info("%s: Failed to get PCI device %x:%x:%x.%x\n", __func__, domain, bus + i, (unsigned)((off >> 3) & 0x1f), (unsigned)(off & 0x07));
+		   pr_err("%s: Failed to get PCI device %x:%x:%x.%x\n", __func__, domain, bus + i, (unsigned)((off >> 3) & 0x1f), (unsigned)(off & 0x07));
 		   continue;
 		   }
 		
@@ -730,7 +735,7 @@ static int mvDmaDrv_DoReset(struct dma_mapping *m, int conditional_reset)
 		err = pcim_enable_device(pdev);
 		
 		if (err) {
-		   pr_info("%s: pcim enable device failed err %d!\n",__func__,err);
+		   pr_err("%s: pcim enable device failed err %d\n",__func__,err);
 		   return err;
 		}
 
@@ -741,13 +746,13 @@ static int mvDmaDrv_DoReset(struct dma_mapping *m, int conditional_reset)
 								if (m->base[i][0]) {
 										val = readl(m->base[i][0] + CNM_PCIE_WIN0_CTRL_REG);
 										if (!(val & PCIE_ADDR_WIN_CTRL_SZ_EN_MASK)) {
-												pr_err("%s: device %d, PCI BAR #2 is not enabled!\n", __func__, i);
+												pr_err("%s: device %d, PCI BAR #2 is not enabled\n", __func__, i);
 												continue;
 											}
 									}
 									 else {
-											pr_err("%s: device %d, BAR #0 is not mappable!\n", __func__, i);
-											continue;
+											pr_err("%s: device %d, BAR #0 is not mappable\n", __func__, i);
+											return -EAGAIN;
 										}
 			
 							/* Only Reset Packet Processor if it was not previously reset: */
@@ -769,13 +774,13 @@ static int mvDmaDrv_DoReset(struct dma_mapping *m, int conditional_reset)
 			if (m->base[i][0]) {
 					val = readl(m->base[i][0] + CNM_PCIE_WIN1_CTRL_REG);
 					if (!(val & PCIE_ADDR_WIN_CTRL_SZ_EN_MASK)) {
-							pr_err("%s: device %d, PCI BAR #4 is not enabled!\n", __func__, i);
+							pr_err("%s: device %d, PCI BAR #4 is not enabled\n", __func__, i);
 							continue;
 						}
 				}
 				 else {
-						pr_err("%s: device %d, BAR #0 is not mappable!\n", __func__, i);
-						continue;
+						pr_err("%s: device %d, BAR #0 is not mappable\n", __func__, i);
+						return -EAGAIN;
 					}
 
 		m->base[i][4] = pcim_iomap(pdev, 4, 8*1024*1024); /* DFX 8M AC3X/BC2/Aldrin only*/
@@ -796,12 +801,12 @@ static int mvDmaDrv_DoReset(struct dma_mapping *m, int conditional_reset)
 				time that the CPU must not approach the device.
 			*/
 
-			pr_info("%s: Preparing PP #%d for reset\n", __func__, i);
+			pr_debug("%s: Preparing PP #%d for reset\n", __func__, i);
 			pci_dev_get(pdev);
 			mvDmaDrv_do_CPSS_skip_sequence_pcie(m->base[i][4]);
 			
 			val = readl(m->base[i][4] + DFX_RST_CTRL_REG);
-			pr_info("%s: PP #%d sending reset\n", __func__, i);
+			pr_debug("%s: PP #%d sending reset\n", __func__, i);
 			val &= ~DFX_SOFT_RST_BITS;
 			
 			mb(); /* Synchronize CPU to finish all writes to PP address space in order to ensure no writes to PP will happen */
@@ -814,11 +819,11 @@ static int mvDmaDrv_DoReset(struct dma_mapping *m, int conditional_reset)
 			
 			pr_info("%s: PP #%d was reset\n", __func__, i);
 			} 
-			else pr_info("%s: base %d BAR4 not mappable!\n", __func__, i);
+			else pr_err("%s: base %d BAR4 not mappable\n", __func__, i);
 		}
 
 	synchronize_rcu();
-	msleep(1000);
+	msleep(10);
 	synchronize_rcu();
 
 	for (i=0; i<2; i++) {
@@ -838,19 +843,40 @@ static void mvdma_free_memory_func(struct work_struct *work)
 	u32 val;
 	int i, ii, ret;
 
-	pr_info("%s: start\n", __func__);
+	pr_debug("%s: start\n", __func__);
 
 	m = container_of(to_delayed_work(work), struct dma_mapping, free_mem_delayed);
 	if (!m->dev) {
-	   pr_info("%s: No PCI device assigned!\n", __func__);
+	   pr_err("%s: No PCI device assigned\n", __func__);
 	   }
 		else	{
+					m->retries_cnt--;
 					ret = mvDmaDrv_stopAndResetSDMA_AC3X_Aldrin_PP(m);
+					if (ret) {
+						if (m->retries_cnt > 0) {
+							schedule_delayed_work(&m->free_mem_delayed, msecs_to_jiffies(1000*SECS_DELAY_WQ));
+							return;
+							}
+							else 
+								pr_alert("%s: failed after retries to map bar#0\n", __func__);
+						}
 					
-					printk("%s: %s: return value of stop and reset PP SDMA RX is: %d\n", 
+					pr_debug("%s: %s: return value of stop and reset PP SDMA RX is: %d\n", 
 							MV_DRV_NAME, __func__, ret);
 			
-					mvDmaDrv_DoReset(m, false);
+					ret = mvDmaDrv_DoReset(m, false);
+					pr_debug("%s: %s: return value of soft reset PP is: %d\n", 
+							MV_DRV_NAME, __func__, ret);
+
+					if (ret) {
+						if (m->retries_cnt > 0) {
+							schedule_delayed_work(&m->free_mem_delayed, msecs_to_jiffies(1000*SECS_DELAY_WQ));
+							return;
+							}
+							else 
+								pr_alert("%s: failed after retries to map bar#0\n", __func__);
+						}
+					
 					for (i=0; i<2; i++) {
 						
 						pdev = m->pdevs_list[i];
@@ -865,7 +891,7 @@ static void mvdma_free_memory_func(struct work_struct *work)
 								continue;
 								}
 
-							pr_info("%s: Unmapping PCI bar %d...\n", __func__, i);
+							pr_debug("%s: Unmapping PCI bar %d...\n", __func__, i);
 							pcim_iounmap(pdev, m->base[i][ii]);
 
 							}
@@ -888,7 +914,7 @@ static int mvDmaDrv_open(struct inode *inode, struct file *file)
 	struct dma_mapping *m;
 
 	down(&mvdma_sem);
-	printk("%s: %s Driver allocating to serve new request...\n", MV_DRV_NAME, __func__);
+	pr_info("%s: %s Driver allocating to serve new request...\n", MV_DRV_NAME, __func__);
 
 	m = kzalloc(sizeof(struct dma_mapping), GFP_KERNEL);
 	if (!m)
@@ -897,7 +923,7 @@ static int mvDmaDrv_open(struct inode *inode, struct file *file)
 	INIT_DELAYED_WORK(&m->free_mem_delayed, mvdma_free_memory_func);
 	file->private_data = m;
 
-	printk("%s: %s(file=%p) data=%p\n", MV_DRV_NAME, __func__, file, m);
+	pr_debug("%s: %s(file=%p) data=%p\n", MV_DRV_NAME, __func__, file, m);
 
 	return 0;
 }
@@ -921,7 +947,7 @@ static loff_t mvDmaDrv_lseek(struct file *file, loff_t off, int unused)
 	if (pdev) {
 		m->pdev = pdev;
 		m->dev = &(pdev->dev);
-		printk("%s: Using PCI device %s\n", MV_DRV_NAME,
+		pr_info("%s: Using PCI device %s\n", MV_DRV_NAME,
 		       m->dev->kobj.name);
 	}
 
@@ -933,9 +959,10 @@ static int mvDmaDrv_release(struct inode *inode, struct file *file)
 {
 	struct dma_mapping *m = (struct dma_mapping *)file->private_data;
 
-	printk("%s: %s(file=%p) data=%p\n", MV_DRV_NAME, __func__, file, m);
+	pr_debug("%s: %s(file=%p) data=%p\n", MV_DRV_NAME, __func__, file, m);
 
-	printk("%s: delaying DMA memory free by %d second...\n", __func__, SECS_DELAY_WQ);
+	pr_info("%s: delaying DMA memory free by %d second...\n", __func__, SECS_DELAY_WQ);
+	m->retries_cnt = MAX_MAP_RETRIES;
 	schedule_delayed_work(&m->free_mem_delayed, msecs_to_jiffies(1000*SECS_DELAY_WQ));
 
 	return 0;
@@ -953,7 +980,7 @@ static int mvdmadrv_pdriver_probe(struct platform_device *pdev)
 
 	platdrv_dev = &pdev->dev;
 
-	printk("%s: Using platform device %s\n", MV_DRV_NAME, pdev->name);
+	pr_info("%s: Using platform device %s\n", MV_DRV_NAME, pdev->name);
 
 	return 0;
 };
@@ -1002,7 +1029,7 @@ static void mvDmaDrv_releaseDrv(void)
 static int mvDmaDrv_PreInitDrv(void)
 {
 	sema_init(&mvdma_sem, 1);
-	printk("%s: %s version %s\n", __func__, MV_DRV_NAME, MV_DRV_NAME_VERSION);
+	pr_info("%s: %s version %s\n", __func__, MV_DRV_NAME, MV_DRV_NAME_VERSION);
 
 	return 0;
 }

--- a/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -53,7 +53,7 @@ disclaimer.
 *       $Revision: 1 $
 *******************************************************************************/
 #define MV_DRV_NAME     "mvIntDrv"
-#define INT_DRV_VER		"1.02"
+#define INT_DRV_VER		"1.11"
 #define MV_DRV_MAJOR    244
 #define MV_DRV_MINOR    4
 #define MV_DRV_FOPS     mvIntDrv_fops
@@ -73,8 +73,10 @@ static struct semaphore mvint_pci_devs_sem;
 
 struct interrupt_slot {
 	int			used;
+	int			depth; /* keep track of enable/disable */
 	unsigned int		irq;
 	struct semaphore	sem; /* The semaphore on which the user waits */
+	struct semaphore	close_sem; /* Sync disconnect with read */
 	struct tasklet_struct	tasklet;
 };
 
@@ -84,6 +86,34 @@ static struct interrupt_slot mvIntDrv_slots[MAX_INTERRUPTS];
 #define MAX_PCI_DEVS 8
 
 struct pci_dev *pci_devs_list[MAX_PCI_DEVS];
+
+void prt_msi_state(char *msg, unsigned bus, unsigned device, unsigned func)
+{
+	struct pci_dev *pdev;
+	u16 control, org_control;
+	u32 msiaddr;
+	
+	pdev = pci_get_domain_bus_and_slot(0, bus,
+					   PCI_DEVFN(device,
+					   func));
+
+	if (pdev) {
+			pci_read_config_word(pdev, pdev->msi_cap + PCI_MSI_FLAGS, &control);
+			pci_read_config_dword(pdev, pdev->msi_cap + PCI_MSI_ADDRESS_LO,
+				      &msiaddr);
+
+			if ((control & PCI_MSI_FLAGS_ENABLE) && (!msiaddr)) {
+				org_control = control;
+				control &= ~PCI_MSI_FLAGS_ENABLE;
+				pci_write_config_word(pdev, pdev->msi_cap + PCI_MSI_FLAGS, control);
+				
+				pr_err("%s: bdf %x:%x:%x msi ctrl %x msi addr low %x msi_enabled %d MISCONFIGURED will disable MSI\n", 
+						msg, bus, device, func, org_control, msiaddr, 
+						pdev->msi_enabled
+						);
+				}
+		}
+}
 
 int mvintdrv_add_pci_dev_to_ar(struct pci_dev *dev)
 {
@@ -139,8 +169,32 @@ void mvintdrv_unregister_isr_sema(struct semaphore *sema)
 }
 EXPORT_SYMBOL(mvintdrv_unregister_isr_sema);
 
+static int find_interrupt_slot(unsigned int irq, bool warn)
+{
+	struct interrupt_slot *sl;
+	int slot;
+
+	for (slot = 0; slot < MAX_INTERRUPTS; slot++) {
+		sl = &(mvIntDrv_slots[slot]);
+		if (sl->irq == irq)
+			return slot;
+	}
+
+	if (warn)
+		printk(KERN_WARNING "%s: No slot allocated for IRQ %d\n",
+		       MV_DRV_NAME, irq);
+
+	return -ENOENT;
+}
+
 static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 {
+	int slot = find_interrupt_slot(irq, true);
+	struct interrupt_slot *sl = &(mvIntDrv_slots[slot]);
+
+	BUG_ON(!sl);
+
+	sl->depth--;
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
@@ -176,17 +230,39 @@ static unsigned int alloc_interrupt_slot(unsigned int irq)
 			sl->used = 1;
 			sl->irq = irq;
 			sema_init(&sl->sem, 0);
+			sema_init(&sl->close_sem, 0);
+			up(&sl->close_sem);
 			tasklet_init(&sl->tasklet, mvPresteraBh,
 				     (unsigned long)sl);
+			prt_msi_state("alloc before req", 1, 0 ,0);
+			prt_msi_state("alloc before req", 2, 0 ,0);
 			if (request_irq(irq, prestera_tl_ISR, IRQF_SHARED,
 					"mvIntDrv", (void *)&sl->tasklet))
 				panic("Can not assign IRQ %u to mvIntDrv\n",
 				      irq);
+			sl->depth--;
+			prt_msi_state("alloc after req", 1, 0 ,0);
+			prt_msi_state("alloc after req", 2, 0 ,0);
 			disable_irq(irq);
+			prt_msi_state("alloc after dis", 1, 0 ,0);
+			prt_msi_state("alloc after dis", 2, 0 ,0);
+			
 			return slot;
 		}
 
 	return MAX_INTERRUPTS;
+}
+
+static void synch_irq_state(struct interrupt_slot *sl)
+{
+	while (sl->depth < 0) {
+		sl->depth++;
+		enable_irq(sl->irq);
+	}
+	while (sl->depth) {
+		sl->depth--;
+		disable_irq(sl->irq);
+	}
 }
 
 /**
@@ -201,11 +277,25 @@ static void free_interrupt_slot(int slot)
 {
 	struct interrupt_slot *sl = &(mvIntDrv_slots[slot]);
 
-	disable_irq(sl->irq);
-	enable_irq(sl->irq);
+	down(&sl->close_sem);
+	/* In inconsistent state (ex race between disable_irq in ISR and
+	   disable_irq in release event) synch to stable state before freeing
+	   the IRQ */
+
+	prt_msi_state("free before synch", 1, 0 ,0);
+	prt_msi_state("free before synch", 2, 0 ,0);
+	synch_irq_state(sl);
+	up(&sl->close_sem);
+	prt_msi_state("free after synch", 1, 0 ,0);
+	prt_msi_state("free after synch", 2, 0 ,0);
+	prt_msi_state("free before freeirq", 1, 0 ,0);
+	prt_msi_state("free before freeirq", 2, 0 ,0);
 	free_irq(sl->irq, (void*)&(sl->tasklet));
+	prt_msi_state("free after freeirq", 1, 0 ,0);
+	prt_msi_state("free after freeirq", 2, 0 ,0);
 	tasklet_kill(&(sl->tasklet));
 	sl->used = 0;
+	sl->irq = 0;
 }
 
 static int intConnect(unsigned int irq)
@@ -226,29 +316,29 @@ static int intConnect(unsigned int irq)
 
 static int intDisConnect(unsigned int irq)
 {
-	struct interrupt_slot *sl;
 	int slot;
 
-	for (slot = 0; slot < MAX_INTERRUPTS; slot++) {
-		sl = &(mvIntDrv_slots[slot]);
-		if (sl->irq == irq) {
-			/* free_interrupt_slot assumes that IRQ state is disabled so userspace must
-			 * ensure this before triggering disconnect */
-			free_interrupt_slot(slot);
-			printk(KERN_DEBUG "%s: disconnected IRQ - %u slot %d\n",
-			       __func__, irq, slot);
-			return slot;
-		}
-	}
+	slot = find_interrupt_slot(irq, true);
+	if (slot == -ENOENT)
+		return 0;
 
-	return 0;
+	/* free_interrupt_slot assumes that IRQ state is disabled so userspace must
+	 * ensure this before triggering disconnect */
+	free_interrupt_slot(slot);
+	printk(KERN_DEBUG "%s: disconnected IRQ - %u slot %d\n", __func__, irq,
+	       slot);
+
+	return slot;
 }
 
 static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_t *off)
 {
+	struct interrupt_slot *sl;
 	unsigned int irq = -1;
 	char cmdBuf[6];
-
+	int slot;
+	u32 msiaddr = 0;
+	
 	/* Write 2 bytes:
 	 * 'c' intNo       - connect interrupt, returns slot+1
 	 * 'd' intNo       - disable interrupt
@@ -296,6 +386,8 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 		break;
 	}
 
+	printk(KERN_DEBUG "%s: %c(%d)\n", MV_DRV_NAME, cmdBuf[0], irq);
+
 	if (cmdBuf[0] == 'c' || cmdBuf[0] == 'C')
 		return intConnect(irq);
 
@@ -303,12 +395,32 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 		return intDisConnect(irq);
 
 	if (cmdBuf[0] == 'd' || cmdBuf[0] == 'D') {
+		slot = find_interrupt_slot(irq, true);
+		if (slot == -ENOENT)
+			return -EINVAL;
+		sl = &(mvIntDrv_slots[slot]);
+		sl->depth--;
+	
+		prt_msi_state("write before disable", 1, 0 ,0);
+		prt_msi_state("write before disable", 2, 0 ,0);
 		disable_irq(irq);
+		prt_msi_state("write after disable", 1, 0 ,0);
+		prt_msi_state("write after disable", 2, 0 ,0);
 		return 0;
 	}
 
 	if (cmdBuf[0] == 'e' || cmdBuf[0] == 'E') {
+		slot = find_interrupt_slot(irq, true);
+		if (slot == -ENOENT)
+			return -EINVAL;
+		sl = &(mvIntDrv_slots[slot]);
+		sl->depth++;
+	
+		prt_msi_state("write before enable", 1, 0 ,0);
+		prt_msi_state("write before enable", 2, 0 ,0);
 		enable_irq(irq);
+		prt_msi_state("write after enable", 1, 0 ,0);
+		prt_msi_state("write after enable", 2, 0 ,0);
 		return 0;
 	}
 
@@ -331,15 +443,29 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 			printk("%s: Cannot reg pdev %p!\n", __func__, pdev);
 			} else pr_info("%s: Queueing pci device for driver cleanup MSI disablement...\n", __func__);
 
+		prt_msi_state("write before msi chk enable", 1, 0 ,0);
+		prt_msi_state("write before msi chk enable", 2, 0 ,0);
 		if (pci_dev_msi_enabled(pdev)) {
 			pr_info("%s: PCIe MSI already enabled.\n", __func__);
-			return 0;
+			prt_msi_state("write after msi enable already", 1, 0 ,0);
+			prt_msi_state("write after msi enable already", 2, 0 ,0);
+			pci_read_config_dword(pdev, pdev->msi_cap + PCI_MSI_ADDRESS_LO,
+				      &msiaddr);
+			return msiaddr ? 0 : -EINVAL;
 		}
+
+		
+		prt_msi_state("write before msi enable", 1, 0 ,0);
+		prt_msi_state("write before msi enable", 2, 0 ,0);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
 		rc = pci_alloc_irq_vectors(pdev, 1, 1, PCI_IRQ_ALL_TYPES);
 #else
 		rc = pci_enable_msi(pdev);
 #endif
+
+		prt_msi_state("write after msi enable", 1, 0 ,0);
+		prt_msi_state("write after msi enable", 2, 0 ,0);
+
 		printk("MSI interrupts for device %s %senabled\n",
 		       pdev->dev.kobj.name, (rc < 0) ? "not " : "");
 
@@ -370,13 +496,29 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 			printk("%s: Cannot reg pdev %p!\n", __func__, pdev);
 			} else pr_info("%s: Queueing pci device for driver cleanup MSI disablement...\n", __func__);
 
+		prt_msi_state("write before msi chk enable", 1, 0 ,0);
+		prt_msi_state("write before msi chk enable", 2, 0 ,0);
+
 		if (pci_dev_msi_enabled(pdev)) {
 			pr_info("%s: PCIe MSI already enabled.\n", __func__);
+			prt_msi_state("write after msi enable already", 1, 0 ,0);
+			prt_msi_state("write after msi enable already", 2, 0 ,0);
+			pci_read_config_dword(pdev, pdev->msi_cap + PCI_MSI_ADDRESS_LO,
+				      &msiaddr);
+			return msiaddr ? 0 : -EINVAL;
+			
 			return 0;
 		}
+
+		prt_msi_state("write before msi enable", 1, 0 ,0);
+		prt_msi_state("write before msi enable", 2, 0 ,0);
+		
 		rc = pci_enable_msi(pdev);
 		printk("MSI interrupts for device %s %senabled\n", pdev->dev.kobj.name,
 		       (rc < 0) ? "not " : "");
+
+		prt_msi_state("write after msi enable", 1, 0 ,0);
+		prt_msi_state("write after msi enable", 2, 0 ,0);
 
 		return rc;
 	}
@@ -385,16 +527,8 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 #endif
 	}
 
-	if (cmdBuf[0] == 'q' || cmdBuf[0] == 'Q') {
-		struct irq_desc *desc = irq_to_desc(irq);
-
-		/* irq desc->action points to the first 'client' the irq needs
-		 * to serve, or NULL if none */
-		if (desc && desc->action)
-			return 1;
-
-		return 0;
-	}
+	if (cmdBuf[0] == 'q' || cmdBuf[0] == 'Q')
+		return find_interrupt_slot(irq, false) != -ENOENT;
 
 	return -EINVAL;
 }
@@ -411,11 +545,26 @@ static ssize_t mvIntDrv_read(struct file *f, char *buf, size_t siz, loff_t *off)
 	if (!sl->used)
 		return -EINVAL;
 
+	prt_msi_state("read before irq enable", 1, 0 ,0);
+	prt_msi_state("read before irq enable", 2, 0 ,0);
+
 	/* Enable the interrupt vector */
+	sl->depth++;
 	enable_irq(sl->irq);
 
+	prt_msi_state("read after irq enable", 1, 0 ,0);
+	prt_msi_state("read after irq enable", 2, 0 ,0);
+
 	if (down_interruptible(&sl->sem)) {
+		down(&sl->close_sem);
+		sl->depth--;
+	
+		prt_msi_state("read before irq disable", 1, 0 ,0);
+		prt_msi_state("read before irq disable", 2, 0 ,0);
 		disable_irq(sl->irq);
+		prt_msi_state("read after irq disable", 1, 0 ,0);
+		prt_msi_state("read after irq disable", 2, 0 ,0);
+		up(&sl->close_sem);
 		return -EINTR;
 	}
 
@@ -437,19 +586,23 @@ static int mvIntDrv_release(struct inode *inode, struct file *file)
 		/* Cleanup */
 		int i, slot;
 		struct interrupt_slot *sl;
-		struct pci_dev *pdev;
+		struct pci_dev *pdev, *pdevs[4] = { NULL, NULL, NULL, NULL };
 		u16 control;
+
 		
+		prt_msi_state("release before msi disable", 1, 0 ,0);
+		prt_msi_state("release before msi disable", 2, 0 ,0);
 		for (i=0; i<MAX_PCI_DEVS; i++) {
 				pdev = mvintdrv_get_pci_dev_from_ar();
 				if (pdev) {
-						printk("%s: Disabling MSI for devfn %x vendor %x devid %x msi_cap %x msi_enabled %d\n",
-							__func__, pdev->devfn, pdev->vendor, pdev->device, pdev->msi_cap, pdev->msi_enabled);
+					    pdevs[i] = pdev;
+						printk("%s: Disabling MSI for %p devfn %x vendor %x devid %x msi_cap %x msi_enabled %d\n",
+							__func__, pdev, pdev->devfn, pdev->vendor, pdev->device, pdev->msi_cap, pdev->msi_enabled);
 /*
- * 						Need to disable MSI before releasing the interrupts, as currently
- * 												the Kernel will only write the MSI address with zero WITHOUT
- * 																		disabling MSI, causing memory overrun of physical address zero in ARM 32-bit:
- * 																		*/
+						Need to disable MSI before releasing the interrupts, as currently
+						the Kernel will only write the MSI address with zero WITHOUT
+						disabling MSI, causing memory overrun of physical address zero in ARM 32-bit:
+*/
 						pci_read_config_word(pdev, pdev->msi_cap + PCI_MSI_FLAGS, &control);
 						control &= ~PCI_MSI_FLAGS_ENABLE;
 						pci_write_config_word(pdev, pdev->msi_cap + PCI_MSI_FLAGS, control);
@@ -457,6 +610,9 @@ static int mvIntDrv_release(struct inode *inode, struct file *file)
 						printk("%s: New MSI control reg value is: %x\n", __func__, control);
 					}
 			}
+
+		prt_msi_state("release after msi disable", 1, 0 ,0);
+		prt_msi_state("release after msi disable", 2, 0 ,0);
 
 		for (slot = 0; slot < MAX_INTERRUPTS; slot++) {
 			sl = &(mvIntDrv_slots[slot]);
@@ -471,7 +627,19 @@ static int mvIntDrv_release(struct inode *inode, struct file *file)
 			 * servicing an interrupt */
 			free_interrupt_slot(slot);
 		}
+
+		prt_msi_state("release after free slot", 1, 0 ,0);
+		prt_msi_state("release after free slot", 2, 0 ,0);
+
+		for (i=0; i<MAX_PCI_DEVS; i++) {
+				if (pdevs[i]) {
+					/*pr_info("%s: disabling msi via kernel for %p\n", __func__, pdevs[i]);
+					pci_disable_msi(pdevs[i]);*/
+				}
+			}
+
 	}
+
 
 	return 0;
 }

--- a/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -53,7 +53,7 @@ disclaimer.
 *       $Revision: 1 $
 *******************************************************************************/
 #define MV_DRV_NAME     "mvIntDrv"
-#define INT_DRV_VER		"1.11"
+#define INT_DRV_VER		"1.16"
 #define MV_DRV_MAJOR    244
 #define MV_DRV_MINOR    4
 #define MV_DRV_FOPS     mvIntDrv_fops
@@ -66,6 +66,7 @@ disclaimer.
 #include <linux/interrupt.h>
 #include <linux/io.h>
 #include <linux/irq.h>
+#include <linux/delay.h>
 
 static int mvIntDrvNumOpened = 0;
 static struct semaphore	*mvIntDrvInterrupsSema; /* Alert other modules on interrupt */
@@ -73,7 +74,7 @@ static struct semaphore mvint_pci_devs_sem;
 
 struct interrupt_slot {
 	int			used;
-	int			depth; /* keep track of enable/disable */
+	atomic_t			depth; /* keep track of enable/disable */
 	unsigned int		irq;
 	struct semaphore	sem; /* The semaphore on which the user waits */
 	struct semaphore	close_sem; /* Sync disconnect with read */
@@ -86,6 +87,27 @@ static struct interrupt_slot mvIntDrv_slots[MAX_INTERRUPTS];
 #define MAX_PCI_DEVS 8
 
 struct pci_dev *pci_devs_list[MAX_PCI_DEVS];
+
+void enable_irq_wrapper(unsigned int irq)
+{
+	struct irq_desc *desc = irq_to_desc(irq);
+
+	if (!desc)
+		return;
+	
+	if (WARN(!desc->irq_data.chip,
+		 KERN_ERR "enable_irq before setup/request_irq: irq %u\n", irq))
+		goto out;
+
+	if (!desc->depth) {
+			pr_err("%s: irq desc depth is zero!!!\n");
+			__sync_bool_compare_and_swap(&desc->depth, 0, 1);
+		}
+	
+out:
+
+	enable_irq(irq);
+}
 
 void prt_msi_state(char *msg, unsigned bus, unsigned device, unsigned func)
 {
@@ -194,7 +216,7 @@ static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 
 	BUG_ON(!sl);
 
-	sl->depth--;
+	atomic_dec(&sl->depth);
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
@@ -240,7 +262,7 @@ static unsigned int alloc_interrupt_slot(unsigned int irq)
 					"mvIntDrv", (void *)&sl->tasklet))
 				panic("Can not assign IRQ %u to mvIntDrv\n",
 				      irq);
-			sl->depth--;
+			atomic_set(&sl->depth, -1); /* assumes depth is zero on call, and decrement it to -1 */
 			prt_msi_state("alloc after req", 1, 0 ,0);
 			prt_msi_state("alloc after req", 2, 0 ,0);
 			disable_irq(irq);
@@ -255,12 +277,12 @@ static unsigned int alloc_interrupt_slot(unsigned int irq)
 
 static void synch_irq_state(struct interrupt_slot *sl)
 {
-	while (sl->depth < 0) {
-		sl->depth++;
+	while (atomic_read(&sl->depth) < 0) {
+		atomic_inc(&sl->depth);
 		enable_irq(sl->irq);
 	}
-	while (sl->depth) {
-		sl->depth--;
+	while (atomic_read(&sl->depth)) {
+		atomic_dec(&sl->depth);
 		disable_irq(sl->irq);
 	}
 }
@@ -399,7 +421,7 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 		if (slot == -ENOENT)
 			return -EINVAL;
 		sl = &(mvIntDrv_slots[slot]);
-		sl->depth--;
+		atomic_dec(&sl->depth);
 	
 		prt_msi_state("write before disable", 1, 0 ,0);
 		prt_msi_state("write before disable", 2, 0 ,0);
@@ -414,11 +436,11 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 		if (slot == -ENOENT)
 			return -EINVAL;
 		sl = &(mvIntDrv_slots[slot]);
-		sl->depth++;
+		atomic_inc(&sl->depth);
 	
 		prt_msi_state("write before enable", 1, 0 ,0);
 		prt_msi_state("write before enable", 2, 0 ,0);
-		enable_irq(irq);
+		enable_irq_wrapper(irq);
 		prt_msi_state("write after enable", 1, 0 ,0);
 		prt_msi_state("write after enable", 2, 0 ,0);
 		return 0;
@@ -434,10 +456,9 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 		int rc;
 
 		pr_info("%s: Got request to enable MSI for %x:%x:%x\n",
-				__func__, (((cmdBuf[2]<<8)&0xff00)|(cmdBuf[1]&0xff)),
-					   (unsigned)cmdBuf[3],
-					   PCI_DEVFN((unsigned)cmdBuf[4],
-						     (unsigned)cmdBuf[5]));
+				__func__, 0, (unsigned)cmdBuf[1],
+					   PCI_DEVFN((unsigned)cmdBuf[2],
+					   (unsigned)cmdBuf[3]));
 
 		if (mvintdrv_add_pci_dev_to_ar(pdev)) {
 			printk("%s: Cannot reg pdev %p!\n", __func__, pdev);
@@ -549,15 +570,15 @@ static ssize_t mvIntDrv_read(struct file *f, char *buf, size_t siz, loff_t *off)
 	prt_msi_state("read before irq enable", 2, 0 ,0);
 
 	/* Enable the interrupt vector */
-	sl->depth++;
-	enable_irq(sl->irq);
+	atomic_inc(&sl->depth);
+	enable_irq_wrapper(sl->irq);
 
 	prt_msi_state("read after irq enable", 1, 0 ,0);
 	prt_msi_state("read after irq enable", 2, 0 ,0);
 
 	if (down_interruptible(&sl->sem)) {
 		down(&sl->close_sem);
-		sl->depth--;
+		atomic_dec(&sl->depth);
 	
 		prt_msi_state("read before irq disable", 1, 0 ,0);
 		prt_msi_state("read before irq disable", 2, 0 ,0);
@@ -589,13 +610,15 @@ static int mvIntDrv_release(struct inode *inode, struct file *file)
 		struct pci_dev *pdev, *pdevs[4] = { NULL, NULL, NULL, NULL };
 		u16 control;
 
+		udelay(1750);
 		
 		prt_msi_state("release before msi disable", 1, 0 ,0);
 		prt_msi_state("release before msi disable", 2, 0 ,0);
-		for (i=0; i<MAX_PCI_DEVS; i++) {
+		for (i=0; i<2; i++) {
 				pdev = mvintdrv_get_pci_dev_from_ar();
 				if (pdev) {
-					    pdevs[i] = pdev;
+						
+						pci_dev_get(pdev);
 						printk("%s: Disabling MSI for %p devfn %x vendor %x devid %x msi_cap %x msi_enabled %d\n",
 							__func__, pdev, pdev->devfn, pdev->vendor, pdev->device, pdev->msi_cap, pdev->msi_enabled);
 /*
@@ -608,9 +631,12 @@ static int mvIntDrv_release(struct inode *inode, struct file *file)
 						pci_write_config_word(pdev, pdev->msi_cap + PCI_MSI_FLAGS, control);
 
 						printk("%s: New MSI control reg value is: %x\n", __func__, control);
+						
 					}
 			}
 
+		udelay(20);
+		
 		prt_msi_state("release after msi disable", 1, 0 ,0);
 		prt_msi_state("release after msi disable", 2, 0 ,0);
 
@@ -631,13 +657,25 @@ static int mvIntDrv_release(struct inode *inode, struct file *file)
 		prt_msi_state("release after free slot", 1, 0 ,0);
 		prt_msi_state("release after free slot", 2, 0 ,0);
 
-		for (i=0; i<MAX_PCI_DEVS; i++) {
-				if (pdevs[i]) {
-					/*pr_info("%s: disabling msi via kernel for %p\n", __func__, pdevs[i]);
-					pci_disable_msi(pdevs[i]);*/
+		udelay(20);
+		for (i=0; i<2; i++) {
+				pdev = pci_get_domain_bus_and_slot(0, 1+i,
+								   PCI_DEVFN(0,
+								   0));
+				pdevs[i] = pdev;
+
+				if (pdev) {
+					pr_info("%s: disabling msi via kernel for %p\n", __func__, pdev);
+					pci_disable_msi(pdev);
 				}
 			}
-
+		
+		udelay(20);
+		
+	for (i=0; i<2; i++) {
+			pdev = pdevs[i];
+			pci_dev_put(pdev);
+		}
 	}
 
 


### PR DESCRIPTION
Move PP Reset to the proper place and handle more cases of MSI enabled with MSI address zero
Handle PP lockup by preventing SDMA / PP Reset when the relevant PCIe bars are disabled.

Signed-off-by: Elad Nachman <enachman@marvell.com>