### PR TITLE
CPSS driver fixes

### DIFF
--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
@@ -162,7 +162,7 @@ enum {
 
 /* Configurable constants */
 #define DRV_NAME "mvppnd_netdev"
-#define MAX_NETDEVS (2 << 8)
+#define MAX_NETDEVS (2 << 10)
 #define DEF_ATU_WIN_AC5X 3
 
 /* How long to wait for SDMA to take ownership of a descriptor */


### PR DESCRIPTION
mvIntDrv: Protect against sigkill of CPSS app
mvEthDrv: Increase maximum device number to 2K