### PR TITLE
Driver upgrade to CPSS_4.3.10_014_SAI

### DIFF
--- a/drivers/generic/common/h/cpss/generic/version/cpssGenStream.h
+++ b/drivers/generic/common/h/cpss/generic/version/cpssGenStream.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define CPSS_STREAM_NAME_CNS "CPSS_4.3.7_014"
+#define CPSS_STREAM_NAME_CNS "CPSS_4.3.10_014"
 
 #ifdef __cplusplus
 }

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/Makefile
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/Makefile
@@ -1,9 +1,18 @@
 # -*-makefile-*-
 # call from kernel build system
 
-TARGETS = mvDmaDrv mvDmaDrv2 mvIntDrv mvMbusDrv mvEthDrv mvSai
+TARGETS = mvcpss
 
 ifneq ($(KERNELRELEASE),)
+
+ifeq ($(CONFIG_KM_MVETH), y)
+# Skip compilation of ethOpsDriver.c and ethDriver.c if Kernel source version is less than 4.14
+cond=$(shell if ( [ $(VERSION) -le 4 ] && [ $(PATCHLEVEL) -lt 14 ] ); then echo 1; else echo 0; fi)
+ifneq ($(cond),1)
+TARGETS += mvEthOpsDrv
+TARGETS += mvSai
+endif
+endif
 
 #Extract the path of the CPSS project into HOME_DIR variable
 ifeq (customer, $(environment_mode))
@@ -15,12 +24,32 @@ endif
 
 ccflags-y := -I$(HOME_DIR)common/h
 obj-m := $(addsuffix .o,$(TARGETS))
-mvDmaDrv-y := dmaDriver.o
-mvDmaDrv2-y := dmaDriver2.o
-mvIntDrv-y := intDriver.o
-mvMbusDrv-y := mbusDriver.o mbusResources.o
-mvEthDrv-y := ethDriver.o
-mvSai-y := saiMod.o
+
+mvEthOpsDrv-$(CONFIG_KM_MVETH) := ethOpsDriver.o
+
+mvcpss-y := mvcpss_main.o
+
+mvcpss-$(CONFIG_KM_MVPCI) += mvpci.o
+ccflags-$(CONFIG_KM_MVPCI) += -DCONFIG_KM_MVPCI
+
+mvcpss-$(CONFIG_KM_MVDMA2) += dmaDriver2.o
+ccflags-$(CONFIG_KM_MVDMA2) += -DCONFIG_KM_MVDMA2
+
+mvcpss-$(CONFIG_KM_MVDMA) += dmaDriver.o
+ccflags-$(CONFIG_KM_MVDMA) += -DCONFIG_KM_MVDMA
+
+mvcpss-$(CONFIG_KM_MVINT) += intDriver.o
+ccflags-$(CONFIG_KM_MVINT) += -DCONFIG_KM_MVINT
+
+mvcpss-$(CONFIG_KM_MVMBUS) += mbusDriver.o mbusResources.o
+ccflags-$(CONFIG_KM_MVMBUS) += -DCONFIG_KM_MVMBUS
+
+ifneq ($(cond), 1)
+mvcpss-$(CONFIG_KM_MVETH) += ethDriver.o
+ccflags-$(CONFIG_KM_MVETH) += -DCONFIG_KM_MVETH
+
+mvSai-$(CONFIG_KM_MVETH) := saiMod.o
+endif
 
 else
 #

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/_Makefile
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/_Makefile
@@ -2,3 +2,21 @@
 
 DRIVER_LIST += nokmDrivers
 DRIVER_DIR_nokmDrivers := $(dir $(lastword $(MAKEFILE_LIST)))
+
+HOST=$(shell hostname)
+PWD=$(shell pwd)
+B=$(shell echo "\#define BUILD_SOURCE \"${USER}@${HOST}:${PWD}\"" > cpssEnabler/mainExtDrv/src/gtExtDrv/linuxNoKernelModule/drivers/srcversion.h)
+$(info ${B})
+
+ISGIT := $(shell git rev-parse --git-dir 2> /dev/null)
+ifneq ($(ISGIT),.git)
+$(warning Not a git directory, omitting git commit ID)
+MODULE_VERSION="N/A"
+else
+GIT_HASH=$(shell git log --oneline -1)
+DIRTY=$(shell git status|grep "Changes not staged for commit"|wc -l)
+MODULE_VERSION=${GIT_HASH} (dirty=$(DIRTY))
+endif
+
+A=$(shell echo "\#define GIT_HASH \"${MODULE_VERSION}\"" >> cpssEnabler/mainExtDrv/src/gtExtDrv/linuxNoKernelModule/drivers/srcversion.h)
+$(info ${A})

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
@@ -1,0 +1,474 @@
+/*******************************************************************************
+Copyright (C) Marvell International Ltd. and its affiliates
+
+This software file (the "File") is owned and distributed by Marvell
+International Ltd. and/or its affiliates ("Marvell") under the following
+alternative licensing terms.  Once you have made an election to distribute the
+File under one of the following license alternatives, please (i) delete this
+introductory statement regarding license alternatives, (ii) delete the
+license alternatives that you have not elected to use and (iii) preserve the
+Marvell copyright notice above.
+
+********************************************************************************
+Marvell GPL License Option
+
+If you received this File from Marvell, you may opt to use, redistribute and/or
+modify this File in accordance with the terms and conditions of the General
+Public License Version 2, June 1991 (the "GPL License"), a copy of which is
+available along with the File in the license.txt file or by writing to the Free
+Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 or
+on the worldwide web at http://www.gnu.org/licenses/gpl.txt.
+
+THE FILE IS DISTRIBUTED AS-IS, WITHOUT WARRANTY OF ANY KIND, AND THE IMPLIED
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE EXPRESSLY
+DISCLAIMED.  The GPL License provides additional details about this warranty
+disclaimer.
+
+*******************************************************************************
+Marvell BSD License Option
+
+If you received this File from Marvell, you may opt to use, redistribute and/or
+modify this File under the following licensing terms.
+Redistribution and use in source and binary forms, with or without modification,
+
+are permitted provided that the following conditions are met:
+
+*   Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+*   Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+*   Neither the name of Marvell nor the names of its contributors may be
+    used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*******************************************************************************/
+
+/*******************************************************************************
+* ethOpsDriver.c
+*
+* DESCRIPTION:
+* The example separate driver (ethOpsDriver.c / mvEthOpsDrv.ko) can be
+* configured from user-space to modify receive packets in various ways,
+* and return any of the four possible actions for the packet.
+* For the transmission path, it can delay packet transmission and
+* additionally it can capture a packet scheduled for transmission
+* and artificially loop it back into the driver as if the was
+* received from the network.
+*
+*
+* DEPENDENCIES:
+*       ethDriver.c .
+*
+* FILE REVISION NUMBER:
+*
+*       $Revision: 1 $
+*
+*******************************************************************************/
+
+#include <linux/module.h>
+#include <linux/netdevice.h>
+#include <linux/kthread.h>
+#include <uapi/linux/sched/types.h>
+#include "ethDriver.h"
+
+MODULE_LICENSE("GPL");
+
+/*!
+  \def DRV_NAME
+  Defines the name of the kernel driver
+*/
+#define DRV_NAME "ethOpsDriver"
+static const char *ifname = "mvpp0";
+static struct net_device *ndev;
+
+struct rx_context {
+	struct task_struct *tg;
+	struct net_device *ndev;
+	char *data;
+	size_t data_len;
+};
+
+enum {
+	TX_OP_MODE_NOP = 0, /*!< No special operation for TX */
+	TX_OP_MODE_TG = 1, /*!< Traffic Generator mode for TX */
+};
+enum {
+	RX_OP_MODE_NOP = 0, /*!< No special operation for RX */
+	RX_OP_MODE_PRINT = 1, /*!< print operation for RX */
+	RX_OP_MODE_REPLACE = 2, /*!< replace operation for RX */
+	RX_OP_MODE_INSERT = 3, /*!< insert operation for RX */
+	RX_OP_MODE_DROP = 4, /*!< drop operation for RX */
+	RX_OP_MODE_PRINT_COUNT = 5, /*!< print count operation for RX */
+	RX_OP_MODE_STOLEN = 6, /*!< stolen buffer by callee operation for RX */
+	RX_OP_MODE_REDIRECT_TO_TX = 7, /*!< redirect to TX operation for RX */
+};
+
+static unsigned int tx_mode = TX_OP_MODE_NOP;
+module_param(tx_mode, uint, 0644);
+MODULE_PARM_DESC(tx_mode, "TX Operation mode:\n\t\t1. Fork traffic generator");
+
+static unsigned int tx_delay_msecs = 0;
+module_param(tx_delay_msecs, uint, 0644);
+MODULE_PARM_DESC(tx_delay_msecs, "Simulate slow TX");
+
+static unsigned int tg_delay_msecs = 1;
+module_param(tg_delay_msecs, uint, 0644);
+MODULE_PARM_DESC(tg_delay_msecs, "traffic generator, msecs delay between packets");
+
+static unsigned int tg_packet_to_dup = 0x0806;
+module_param(tg_packet_to_dup, uint, 0644);
+MODULE_PARM_DESC(tg_packet_to_dup, "traffic generator, packet to capture from TX to be used for RX emulation");
+
+static unsigned int tg_mon_sent = 0;
+module_param(tg_mon_sent, uint, 0444);
+MODULE_PARM_DESC(tg_mon_sent, "traffic generator, sent packets counter");
+
+static unsigned int tg_mon_drops = 0;
+module_param(tg_mon_drops, uint, 0444);
+MODULE_PARM_DESC(tg_mon_drops, "traffic generator, droped packets counter");
+
+static unsigned int rx_mode = RX_OP_MODE_NOP;
+module_param(rx_mode, uint, 0644);
+MODULE_PARM_DESC(rx_mode,
+		 "RX Operation mode:\n\t\t1. print buf\n\t\t2. Replace some bytes\n\t\t3. Insert some bytes\n\t\t4. Drop\n\t\t5. Count\n\t\t6. Stolen\n\t\t7. Redirect to TX");
+
+static char *rx_data = "Yuval";
+module_param(rx_data, charp, 0644);
+MODULE_PARM_DESC(rx_data, "String to be used for RX mode 1 and 2");
+
+static unsigned int rx_data_pos = 0;
+module_param(rx_data_pos, uint, 0644);
+MODULE_PARM_DESC(rx_data_pos, "Possition to place the string (max page_size) for RX mode 1 and 2");
+
+static unsigned int rx_counter_dump = 10000;
+module_param(rx_counter_dump, uint, 0644);
+MODULE_PARM_DESC(rx_counter_dump, "Counter, when exceeds print message");
+
+struct rx_context rx_ctx = {};
+
+/**
+* @internal print_buf function
+* @endinternal
+*
+* @brief  prints the given binary buffer as text string
+*
+* @param[in] title                   - title to print
+* @param[in] data                    - binary data to print
+* @param[in] len                     - length of binary data to print, in bytes
+*
+* @retval void
+*/
+static void print_buf(const char *title, const unsigned char *data, size_t len)
+{
+	size_t sz;
+	char *b;
+	int i;
+
+	sz = (len * 3) + 4 + strlen(title) + 1 + 1;
+
+	b = kmalloc(sz, GFP_KERNEL);
+	if (!b)
+		return;
+
+	sprintf(b, "len %ld:", len);
+	for (i = 0; i < len; i++)
+		sprintf(b, "%s %.2x", b, data[i]);
+	pr_info("%s: %s\n", title, b);
+
+	/*
+	sprintf(b, "len %ld:", len);
+	for (i = 0; i < len; i++)
+		sprintf(b, "%s %c", b, data[i]);
+
+	printk("%s: %s\n", title, b);
+	*/
+
+	kfree(b);
+}
+
+/**
+* @internal process_rx function
+* @endinternal
+*
+* @brief  RX hook callback processing function
+*         Modifies the packet according to the rx_mode configured:
+* 	  RX_OP_MODE_NOP: No special operation for RX
+* 	  RX_OP_MODE_PRINT: print operation for RX
+* 	  RX_OP_MODE_REPLACE: replace operation for RX
+* 	  RX_OP_MODE_INSERT: insert operation for RX
+* 	  RX_OP_MODE_DROP: drop operation for RX
+* 	  RX_OP_MODE_PRINT_COUNT:  print count operation for RX
+* 	  RX_OP_MODE_STOLEN: stolen buffer by callee operation for RX
+* 	  RX_OP_MODE_REDIRECT_TO_TX: redirect to TX operation for RX
+*
+* @param[in] ndev               - Linux Kernel network device structure pointer
+* @param[in] data               - data of received buffer to process
+* @param[in,out] sz             - pointer to size of received buffer to process
+*                                 Can be updated by this function
+* @param[in] data               - maximum size of received buffer for expansion
+*                                 purposes (when updating sz above)
+*
+* @retval NF_DROP               - When requesting to drop the packet
+* @retval NF_ACCEPT             - When requesting to pass onwards the packet
+* @retval NF_STOLEN             - When the packet is handled by this function
+* @retval NF_QUEUE              - When requesting to redirect the packet to TX
+*/
+int process_rx(struct net_device *ndev, unsigned char *data, int *sz,
+	       int max_sz)
+{
+	static int counter = 0;
+	char *tmp_data, *p;
+	int new_size;
+
+	switch (rx_mode) {
+	case RX_OP_MODE_PRINT:
+		/* Just print */
+		print_buf("rx", data, *sz);
+		break;
+	case RX_OP_MODE_REPLACE:
+		/* Modify the buffer content, without changing the size */
+		print_buf("nf1-before", data, *sz);
+		if (rx_data_pos + strlen(rx_data) <= *sz)
+			memcpy(data + rx_data_pos, rx_data, strlen(rx_data));
+		print_buf("nf1-after ", data, *sz);
+		break;
+	case RX_OP_MODE_INSERT:
+		/* Add some bytes to buffer, will increase the buffer size.*/
+		print_buf("nf2-before", data, *sz);
+		new_size = *sz + strlen(rx_data);
+		if ((rx_data_pos < *sz) && (new_size < max_sz)) {
+			p = tmp_data = kmalloc(new_size + 1, GFP_KERNEL);
+			memcpy(p, data, rx_data_pos);
+			p += rx_data_pos;
+			memcpy(p, rx_data, strlen(rx_data));
+			p += strlen(rx_data);
+			memcpy(p, data + rx_data_pos, *sz - rx_data_pos);
+
+			memcpy(data, tmp_data, new_size);
+			*sz = new_size;
+
+			kfree(tmp_data);
+		}
+		print_buf("nf2-after ", data, *sz);
+		break;
+	case RX_OP_MODE_DROP:
+		/* Drop packet */
+		return NF_DROP;
+	case RX_OP_MODE_PRINT_COUNT:
+		/* Print message after every $rx_counter_dump messages */
+		if (++counter == rx_counter_dump) {
+			dev_info(&ndev->dev, "%s: Got %d packets\n", DRV_NAME,
+				 counter);
+			counter = 0;
+		}
+		break;
+	case RX_OP_MODE_STOLEN:
+		return NF_STOLEN;
+	case RX_OP_MODE_REDIRECT_TO_TX:
+		return NF_QUEUE; /* Utilize as redirect to TX */
+	default:
+		/* Ignore */
+		break;
+	};
+
+	return NF_ACCEPT;
+}
+
+/**
+* @internal rx_traffic_generator function
+* @endinternal
+*
+* @brief  Simulates reception of frames into the RX path of the ethDriver
+*
+* @param[in] data                  - pointer to RX simulation context structure
+*
+* @retval always zero
+*/
+static int rx_traffic_generator(void *data)
+{
+	struct rx_context *ctx = (struct rx_context *)data;
+	u8 dsa[DSA_SIZE] = {};
+	int rc, queue = 0;
+
+	while (!kthread_should_stop()) {
+		if (tx_mode != 1) {
+			msleep(500);
+			continue;
+		}
+
+		/* Push while we can */
+		rc = mvppnd_emulate_rx(ctx->ndev, &dsa[0], ctx->data,
+				       ctx->data_len, queue);
+		if (rc > 0)
+			mdelay(tg_delay_msecs);
+		else
+			tg_mon_drops++;
+
+		tg_mon_sent++;
+
+		if (++queue >= NUM_OF_RX_QUEUES)
+			queue = 0;
+	};
+
+	return 0;
+}
+
+/**
+* @internal free_rx_context function
+* @endinternal
+*
+* @brief  Stops RX simulation and free the RX simulation context structure
+*
+* @param[in] void
+*
+* @retval void
+*/
+static void free_rx_context(void)
+{
+	if (!rx_ctx.data)
+		return;
+
+	kthread_stop(rx_ctx.tg);
+	mdelay(tg_delay_msecs * 2);
+
+	kfree(rx_ctx.data);
+}
+
+/**
+* @internal process_tx function
+* @endinternal
+*
+* @brief  TX hook callback processing function:
+*         if configured so, and the packet matches
+*	  the configured protocol number, simulates
+*	  loop reception of this specific packet into
+*	  the RX path of the ethDriver.
+*	  In any case, delays the packet before
+*	  transmitting it.
+*
+* @param[in] ndev               - Linux Kernel network device structure pointer
+* @param[in] data               - data of received buffer to process
+* @param[in,out] sz             - pointer to size of received buffer to process
+*                                 Can be updated by this function
+* @param[in] data               - maximum size of received buffer for expansion
+*                                 purposes (when updating sz above)
+*
+* @retval NF_DROP               - When requesting to drop the packet
+* @retval NF_ACCEPT             - When requesting to pass onwards the packet
+* @retval NF_STOLEN             - When the packet is handled by this function
+*/
+int process_tx(struct net_device *ndev, struct sk_buff *skb)
+{
+	struct ethhdr *eth_hdr = (struct ethhdr *)skb->data;
+
+	switch (tx_mode) {
+	case TX_OP_MODE_TG:
+		if ((!rx_ctx.data) && ((be16_to_cpu(eth_hdr->h_proto)) ==
+		    tg_packet_to_dup)) {
+			/* No support for frags */
+			rx_ctx.data_len = skb_headlen(skb);
+			rx_ctx.data = kmalloc(rx_ctx.data_len, GFP_KERNEL);
+			if (!rx_ctx.data) {
+				dev_err(&ndev->dev,
+					"%s: Fail to allocate memory for data\n",
+					DRV_NAME);
+				return NF_ACCEPT;
+			}
+
+			memcpy(rx_ctx.data, skb->data, rx_ctx.data_len);
+			rx_ctx.ndev = ndev;
+			rx_ctx.tg = kthread_run(rx_traffic_generator,
+						(void *)&rx_ctx, DRV_NAME);
+		}
+	}
+
+	/* Simulate slow TX */
+	mdelay(tx_delay_msecs);
+
+	return NF_ACCEPT;
+}
+
+static struct mvppnd_ops ops = {
+	.process_rx = process_rx,
+	.process_tx = process_tx,
+};
+
+/**
+* @internal ethopsdrv_init function
+* @endinternal
+*
+* @brief  Module's initialization function
+*	  Registers RX/TX hooks callback
+*	  function in ethDriver.
+*
+* @param[in] void
+*
+* @retval EIO                         - on error
+* @retval zero                        - on success
+*/
+static int __init ethopsdrv_init(void)
+{
+	int rc;
+
+	ndev = dev_get_by_name(&init_net, ifname);
+	if (!ndev) {
+		pr_err("Fail to find netdev %s\n", ifname);
+		return -EIO;
+	}
+
+	rc = mvppnd_register_hooks(ndev, &ops);
+	if (rc) {
+		dev_put(ndev);
+		dev_err(&ndev->dev, "Fail to register to mvppnd\n");
+		return -EIO;
+	}
+
+	pr_info("%s: driver hooked\n", DRV_NAME);
+
+	return 0;
+}
+
+/**
+* @internal ethopsdrv_exit function
+* @endinternal
+*
+* @brief  Module's De-initialization function
+*	  Un-Registers RX/TX hooks callback
+*	  function in ethDriver, and frees
+*	  RX simulation RX.
+*
+* @param[in] void
+*
+* @retval void
+*/
+static void __exit ethopsdrv_exit(void)
+{
+	mvppnd_register_hooks(ndev, NULL);
+
+	free_rx_context();
+
+	dev_put(ndev);
+
+	pr_info("%s: driver un-hooked\n", DRV_NAME);
+}
+
+module_init(ethopsdrv_init);
+module_exit(ethopsdrv_exit);
+
+MODULE_AUTHOR("Yuval Shaia <yshaia@marvell.com>");
+MODULE_DESCRIPTION("rx hook example");
+MODULE_LICENSE("Dual BSD/GPL");

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusResources.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusResources.c
@@ -39,7 +39,6 @@ disclaimer.
 * DEPENDENCIES:
 *       DTB database is used, so Linux 3.10+ required
 *
-*       $Revision: 1 $
 *******************************************************************************/
 #if defined(CONFIG_OF)
 
@@ -194,75 +193,81 @@ int mvGetResourceInfo(int resource, struct mv_resource_info *res)
 }
 
 struct mvMbusResource{
-    unsigned int resource;
-    unsigned int size;
-    unsigned int offset;
+	unsigned int resource;
+	unsigned int size;
+	unsigned int offset;
 };
 
 static struct mvMbusResource mvMbusResourceAc5[] = {
-    { MV_RESOURCE_MBUS_RUNIT,   SZ_4M + SZ_1M   , 0x80000000},
-    { MV_RESOURCE_MBUS_SWITCH,  SZ_2G - SZ_4    , 0x00000000},
-    { MV_RESOURCE_MBUS_DFX,     SZ_1M           , 0x84000000},
-    { -1, 0, 0 }
+	{ MV_RESOURCE_MBUS_RUNIT,   SZ_4M + SZ_1M   , 0x80000000},
+	{ MV_RESOURCE_MBUS_SWITCH,  SZ_2G - SZ_4    , 0x00000000},
+	{ MV_RESOURCE_MBUS_DFX,     SZ_1M           , 0x84000000},
+	{ -1, 0, 0 }
 };
 
 static struct mvMbusResource mvMbusResourceAc5x[] = {
-    { MV_RESOURCE_MBUS_RUNIT,   SZ_16M  , 0x7F000000},
-    { MV_RESOURCE_MBUS_SWITCH,  SZ_1G   , 0x80000000},
-    { MV_RESOURCE_MBUS_DFX,     SZ_1M   , 0x94400000},
-    { -1, 0, 0 }
+	{ MV_RESOURCE_MBUS_RUNIT,   SZ_16M  , 0x7F000000},
+	{ MV_RESOURCE_MBUS_SWITCH,  SZ_1G   , 0x80000000},
+	{ MV_RESOURCE_MBUS_DFX,     SZ_1M   , 0x94400000},
+	{ -1, 0, 0 }
+};
+
+static struct mvMbusResource mvMbusResourceIml[] = {
+	{ MV_RESOURCE_MBUS_RUNIT,   SZ_16M + SZ_64M, 0x7F000000},
+	{ MV_RESOURCE_MBUS_SWITCH,  SZ_1G          , 0x84200000},
+	{ MV_RESOURCE_MBUS_DFX,     SZ_1M          , 0x84000000},
+	{ -1, 0, 0 }
 };
 
 int mvGetSip6ResourceInfo(int resource, int device, struct mv_resource_info *res) {
 
-    int i;
-    u32 devId;
-    struct pci_dev *cpu_dev = NULL;
+	int i;
+	u32 devId;
+	/*struct pci_dev *cpu_dev = NULL;*/
 
-    static struct mvMbusResource *mvMbusResource = NULL;
+	static struct mvMbusResource *mvMbusResource = NULL;
 
-    if(device == MV_MBUS_DRV_DEV_ID_AC5) {
-        mvMbusResource = mvMbusResourceAc5;
-    } else if(device == MV_MBUS_DRV_DEV_ID_AC5X) {
-        mvMbusResource = mvMbusResourceAc5x;
-    } else {
-        return -1;
-    }
+	if(device == CNM_DEV_ID_VAL_AC5) {
+		mvMbusResource = mvMbusResourceAc5;
+	} else if(device == CNM_DEV_ID_VAL_AC5X) {
+		mvMbusResource = mvMbusResourceAc5x;
+	} else if((device == CNM_DEV_ID_VAL_IML) ||
+			  (device == CNM_DEV_ID_VAL_IMM)) {
+		mvMbusResource = mvMbusResourceIml;
+	} else {
+		return -1;
+	}
 
-    switch (resource) {
+	switch (resource) {
 
-        case MV_RESOURCE_DEV_ID:
-            cpu_dev = pci_get_device(0x11ab, PCI_ANY_ID, cpu_dev);
-            if (cpu_dev == NULL){
-            return 0;
-            }
-            devId = cpu_dev->device;
-            res->start = (phys_addr_t)devId;
-            res->size = 0;
-            return 0;
+		case MV_RESOURCE_DEV_ID:
+			devId = mvGetDeviceId() >> 4;
+			res->start = (phys_addr_t)devId;
+			res->size = 0;
+			return 0;
 
-        case MV_RESOURCE_MBUS_SWITCH:
-        case MV_RESOURCE_MBUS_RUNIT:
-        case MV_RESOURCE_MBUS_DFX:
+		case MV_RESOURCE_MBUS_SWITCH:
+		case MV_RESOURCE_MBUS_RUNIT:
+		case MV_RESOURCE_MBUS_DFX:
 
-            for(i=0; i<(sizeof(mvMbusResourceAc5)/sizeof(struct mvMbusResource)); i++) {
-                if(mvMbusResource[i].resource == resource) {
-                    res->start = mvMbusResource[i].offset;
-                    res->size = mvMbusResource[i].size;
-                    return 0;
-                }
-            }
-            break;
+			for(i=0; i<(sizeof(mvMbusResourceAc5)/sizeof(struct mvMbusResource)); i++) {
+				if(mvMbusResource[i].resource == resource) {
+					res->start = mvMbusResource[i].offset;
+					res->size = mvMbusResource[i].size;
+					return 0;
+				}
+			}
+			break;
 
-        case MV_RESOURCE_MBUS_SWITCH_IRQ:
-            return mvGetMbusInterrupt(res);
-            break;
+		case MV_RESOURCE_MBUS_SWITCH_IRQ:
+			return mvGetMbusInterrupt(res);
+			break;
 
-        default:
-            break;
-    }
+		default:
+			break;
+	}
 
-    return -1;
+	return -1;
 }
 
 int mvGetDeviceId(void)
@@ -283,6 +288,17 @@ int mvGetDeviceId(void)
 			if(strncmp(model, ac3_model, strlen(ac3_model)) == 0) {
 				pr_info("Detected AC3\n");
 			} else {
+/*
+ * Mbus driver is expected to be used with AC3, AC5, AC5X, IM-L and IM-M ONLY
+ *
+ * AC5, AC5X, IM-L and IM-M CnM unit contain a dual core Armv8-A PE (Cortex-A55)
+ * Above PPs also contain device ID registers which are read to identify PP type
+ *
+ * Attempting to read these registers on older generation of external SoC used
+ * with PPs such as PIPE lead to "Unhandled fault" resulting in undefined
+ * behaviour. Hence limiting below logic to AC5, AC5X, IM-L and IM-M with Armv8-A PE
+ */
+#ifdef __aarch64__
 				dev_id_reg_res = request_mem_region(CNM_DEV_ID_REG_ADDR, CNM_DEV_ID_REG_SIZE, "CnM Device ID Register");
 				if(dev_id_reg_res) {
 					dev_id_reg = ioremap(CNM_DEV_ID_REG_ADDR, CNM_DEV_ID_REG_SIZE);
@@ -292,21 +308,12 @@ int mvGetDeviceId(void)
 					}
 					release_mem_region(CNM_DEV_ID_REG_ADDR, CNM_DEV_ID_REG_SIZE);
 				}
-
-				if((dev_id & CNM_DEV_ID_VAL_MASK) == CNM_DEV_ID_VAL_AC5) {
-					pr_info("Detected AC5, DEV ID = %x\n",(dev_id & CNM_DEV_ID_VAL_MASK));
-					return MV_MBUS_DRV_DEV_ID_AC5;
-				} else if((dev_id & CNM_DEV_ID_VAL_MASK) == CNM_DEV_ID_VAL_AC5X) {
-					pr_info("Detected AC5X, DEV ID = %x\n",(dev_id & CNM_DEV_ID_VAL_MASK));
-					return MV_MBUS_DRV_DEV_ID_AC5X;
-				} else {
-					pr_info("Detected Unknown Device, DEV ID = %x\n", (dev_id & CNM_DEV_ID_VAL_MASK));
-				}
+#endif
 			}
 		}
 	}
 
-	return MV_MBUS_DRV_DEV_ID_UNKNOWN;
+	return dev_id;
 }
 
 #endif /* CONFIG_OF */

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/multi-port-init.sh
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/multi-port-init.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+appdemo=appDemo
+cpss_init_system_cmd="cpssInitSystem 35,7,0 portMgr" # Falcon-4t
+ethdrv=yuval/eth-stuff/mvEthDrv.ko
+
+mg=0
+sdma_rx_queue=0
+sdma_tx_queue=5
+subnet_mask=24
+port_netdev_mac_prefix="00:50:43"
+port_netdev_ip_suffix="19.1.10"
+tx_dsa_tags_file=/tmp/tx_dsa_tags # list of tx_tsa tags, line per port 16 bytes hex format, no 0x prefix
+port_rx_dsa_mask="00 F8 00 00 00 00 0c 00 00 30 00 00 00 00 00 00"
+
+random_mac_file=/tmp/random_mac_file
+cpss_cmd_file=/tmp/cpss_cmd_file.lua
+cpss_netdev_demo_cmd="appDemoNetDevDemo"
+
+# Some validations
+if [ ! -f ${tx_dsa_tags_file} ]; then
+	echo "File ${tx_dsa_tags_file} not found"
+	exit 1
+fi
+if [ ! -f ${ethdrv} ]; then
+	echo "File ${ethdrv} not found"
+	exit 1
+fi
+if [ ! -f ${appdemo} ]; then
+	echo "File ${appdemo} not found"
+	exit 1
+fi
+
+# How many ports are configure
+t1=$(wc -l ${tx_dsa_tags_file})
+set ${t1}
+max_ports=$1
+if [ ${max_ports} -lt 1 ]; then
+	echo "File ${tx_dsa_tags_file} is empty"
+	exit 1
+fi
+
+# Create config file to be run when appDemo starts if not exist
+# Set the last parameter ignorePortCfg=0 while calling appDemoNetDevDemo()
+# Vaule 0 means the multi-port port configuration is applied with the
+# default setting (VLAN, PVID, MAC entry).
+# Value 1 means the application apply the port configuration manually.
+if [ ! -f ${cpss_cmd_file} ]; then
+	echo "${cpss_init_system_cmd}" > ${cpss_cmd_file}
+	echo "do shell-execute ${cpss_netdev_demo_cmd} \"${random_mac_file}\" \"${port_netdev_mac_prefix}\" ${sdma_rx_queue} 0" >> ${cpss_cmd_file}
+fi
+
+rm -f ${random_mac_file}
+
+echo -n "Executing ${appdemo} "
+# Run appDemo in background and wait for MAC file to be created
+${appdemo} -daemon -config ${cpss_cmd_file}
+while [ ! -f ${random_mac_file} ]; do sleep 1;echo -n "."; done
+echo ""
+read random_mac_byte_4_and_5 < ${random_mac_file}
+
+echo "Loading ${ethdrv}"
+# Load and configure eth driver
+netdev_name="mvpp0"
+/sbin/rmmod mvEthDrv 2>/dev/null
+/sbin/insmod ${ethdrv}
+# Let driver listen to all queues, if needed configure to which to listen
+#sdma_rx_queue_mask=$(printf "0x%x\n" $((1 << ${sdma_rx_queue})))
+sdma_rx_queue_mask=0xFF
+echo ${mg} > /sys/class/net/${netdev_name}/mg
+echo ${sdma_rx_queue_mask} > /sys/class/net/${netdev_name}/rx_queues
+echo ${sdma_tx_queue} > /sys/class/net/${netdev_name}/tx_queue
+ip link set ${netdev_name} up arp on
+# Create netdevs for all ports
+#port_rx_dsa_mask=$(echo ${port_rx_dsa_mask} | sed 's/ / 0x/g' | sed 's/^/0x/')
+echo "Creating ${max_ports} netdevs"
+port_num=1
+while [ ${port_num} -le ${max_ports} ];
+do
+	port_name=${netdev_name}.${port_num}
+	port_tx_dsa_tag=$(sed -n ${port_num}p ${tx_dsa_tags_file})
+
+	echo "${port_name} ${port_num}" > /sys/class/net/${netdev_name}/if_create
+	port_num_hex=$(printf "%.2x" $((${port_num} - 1)))
+	echo "${port_netdev_mac_prefix}:${random_mac_byte_4_and_5}:${port_num_hex}" > /sys/class/net/${port_name}/mac
+
+	echo "${port_tx_dsa_tag}" > /sys/class/net/${port_name}/dsa
+	echo "${port_rx_dsa_mask}" > /sys/class/net/${port_name}/rx_dsa_mask
+
+	pn=$((${port_num} - 1))
+	b1=$(($((${pn} & 0x1f)) << 3))
+	b6=$(($(($((${pn} & 0x60)) >> 5)) << 2))
+	b9=$(($(($((${pn} & 0x180)) >> 7)) << 4))
+	port_rx_dsa_val=$(printf "00 %.2x 00 00 00 00 %02x 00 00 %.2x 00 00 00 00 00 00" ${b1} ${b6} ${b9})
+	echo "${port_rx_dsa_val}" > /sys/class/net/${port_name}/rx_dsa_val
+
+	ip addr add ${port_num}.${port_netdev_ip_suffix}/${subnet_mask} dev ${port_name}
+	ip link set ${port_name} up arp on
+
+	ifconfig ${port_name} up
+
+	port_num=$((${port_num} + 1))
+done
+echo "Done"
+exit 0

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvResources.h
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvResources.h
@@ -33,7 +33,6 @@ disclaimer.
 *
 * DEPENDENCIES:
 *
-*       $Revision: 1 $
 *******************************************************************************/
 #ifndef __mvResources_h__
 #define __mvResources_h__
@@ -67,15 +66,13 @@ int mvGetDeviceId(void);
 #define IOCTL_MV_MBUS_DRV_MAGIC         'M'
 #define IOCTL_MV_MBUS_DRV_SET_DEV_ID    _IOW(IOCTL_MV_MBUS_DRV_MAGIC, 1, int)
 
-#define MV_MBUS_DRV_DEV_ID_UNKNOWN      0
-#define MV_MBUS_DRV_DEV_ID_AC5          1
-#define MV_MBUS_DRV_DEV_ID_AC5X         2
-
 #define CNM_DEV_ID_REG_ADDR         0x7F90004C
 #define CNM_DEV_ID_REG_SIZE         4
 #define CNM_DEV_ID_VAL_AC5          0x000B4000
 #define CNM_DEV_ID_VAL_AC5X         0x00098000
-#define CNM_DEV_ID_VAL_MASK         0x000FF000
+#define CNM_DEV_ID_VAL_IML          0x000A0000
+#define CNM_DEV_ID_VAL_IMM          0x000A2000
+#define CNM_DEV_ID_VAL_MASK         0x000FE000
 
 #endif /* __mvResources_h__ */
 

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvcpss_main.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvcpss_main.c
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) Marvell International Ltd. and its affiliates
+ *
+ * This software file (the "File") is owned and distributed by Marvell
+ * International Ltd. and/or its affiliates ("Marvell") under the following
+ * alternative licensing terms.  Once you have made an election to distribute
+ * the file under one of the following license alternatives, please (i) delete
+ * this introductory statement regarding license alternatives, (ii) delete the
+ * two license alternatives that you have not elected to use and (iii) preserve
+ * the Marvell copyright notice above.
+ *
+ *******************************************************************************
+ * Marvell GPL License Option
+
+ * If you received this File from Marvell, you may opt to use, redistribute
+ * and/or modify this File in accordance with the terms and conditions of the
+ * General Public License Version 2, June 1991 (the "GPL License"), a copy of
+ * which is available along with the File in the license.txt file or by writing
+ * to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 or on the worldwide web at http://www.gnu.org/licenses/gpl.txt.
+ *
+ * THE FILE IS DISTRIBUTED AS-IS, WITHOUT WARRANTY OF ANY KIND, AND THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ * EXPRESSLY DISCLAIMED.  The GPL License provides additional details about this
+ * warranty disclaimer.
+*/
+
+/*
+ * @file mvcpss_main.c
+ *
+ * @brief Marvell's CPSS utilities kernel module
+ *
+ * @author Yuval Shaia <yshaia@marvell.com>
+ *
+ */
+
+#include <linux/module.h>
+#include <cpss/generic/version/cpssGenStream.h>
+#include "srcversion.h"
+
+#define MODULE_NAME "mvcpss"
+
+#ifdef CONFIG_KM_MVPCI
+extern int mvpci_init(void);
+extern void mvpci_exit(void);
+static unsigned int en_func_pci = 1;
+module_param(en_func_pci, uint, 0644);
+MODULE_PARM_DESC(en_func_pci, "Enable PCI function 0/1");
+#endif
+
+#ifdef CONFIG_KM_MVDMA2
+extern int mvdma2_init(void);
+extern void mvdma2_exit(void);
+static unsigned int en_func_dma2 = 1;
+module_param(en_func_dma2, uint, 0644);
+MODULE_PARM_DESC(en_func_dma2, "Enable DMA2 function 0/1");
+#endif
+
+#ifdef CONFIG_KM_MVDMA
+extern int mvdmadrv_init(void);
+extern void mvdmadrv_exit(void);
+static unsigned int en_func_dma = 1;
+module_param(en_func_dma, uint, 0644);
+MODULE_PARM_DESC(en_func_dma, "Enable DMA function 0/1");
+#endif
+
+#ifdef CONFIG_KM_MVINT
+extern int mvintdrv_init(void);
+extern void mvintdrv_exit(void);
+static unsigned int en_func_int = 1;
+module_param(en_func_int, uint, 0644);
+MODULE_PARM_DESC(en_func_int, "Enable INT function 0/1");
+#endif
+
+#ifdef CONFIG_KM_MVMBUS
+extern int mvmbusdrv_init(void);
+extern void mvmbusdrv_exit(void);
+static unsigned int en_func_mbus = 1;
+module_param(en_func_mbus, uint, 0644);
+MODULE_PARM_DESC(en_func_mbus, "Enable MBUS function 0/1");
+#endif
+
+#ifdef CONFIG_KM_MVETH
+extern int mvppnd_init(void);
+extern void mvppnd_exit(void);
+static unsigned int en_func_eth = 1;
+module_param(en_func_eth, uint, 0644);
+MODULE_PARM_DESC(en_func_eth, "Enable ETH function 0/1");
+#endif
+
+#if defined(CONFIG_KM_MVDMA) && defined(CONFIG_KM_MVDMA2)
+#warning "Invalid combination DMA=y and DMA2=y"
+#endif
+
+#if defined(CONFIG_KM_MVINT) && !defined(CONFIG_KM_MVPCI) && !defined(CONFIG_KM_MVMBUS) && !defined(CONFIG_KM_MVETH)
+#warning "Invalid combination INT=y PCI=n, MBUS=n and ETH=n"
+#endif
+
+static inline void mvcpss_init_module(int (*module_init_func)(void),
+				      const char *func_name, int *enable)
+{
+	int rc;
+
+	if (!*enable)
+		return;
+
+	rc = module_init_func();
+	if (rc) {
+		pr_err("%s: Fail to initialize %s function\n", MODULE_NAME,
+		       func_name);
+		*enable = 0; /* So module_exit will not get called */
+	} else {
+		pr_info("%s: Function %s loaded\n", MODULE_NAME,
+			func_name);
+	}
+}
+
+static inline void mvcpss_exit_module(void (*module_exit_func)(void),
+				      const char *func_name, int enable)
+{
+	if (!enable)
+		return;
+
+	module_exit_func();
+
+	pr_info("%s: Function %s unloaded\n", MODULE_NAME, func_name);
+}
+
+static int mvcpss_init(void)
+{
+#if defined(CONFIG_KM_MVINT) || defined(CONFIG_KM_MVPCI) || defined(CONFIG_KM_MVETH)
+	bool pci = false;
+#endif
+#if defined(CONFIG_KM_MVINT) || defined(CONFIG_KM_MVMBUS)
+	bool mbus = false;
+#endif
+
+#ifdef CONFIG_KM_MVPCI
+	mvcpss_init_module(mvpci_init, "PCI", &en_func_pci);
+	pci = en_func_pci;
+#endif
+
+#ifdef CONFIG_KM_MVDMA2
+#ifdef CONFIG_KM_MVDMA
+	if (en_func_dma && en_func_dma2)
+		pr_warn("%s: Both DMA and DMA2 selected\n", MODULE_NAME);
+#endif
+	mvcpss_init_module(mvdma2_init, "DMA2", &en_func_dma2);
+#endif
+
+#ifdef CONFIG_KM_MVDMA
+#ifdef CONFIG_KM_MVDMA2
+	if (en_func_dma && en_func_dma2)
+		pr_warn("%s: Both DMA and DMA2 selected\n", MODULE_NAME);
+#endif
+	mvcpss_init_module(mvdmadrv_init, "DMA", &en_func_dma);
+#endif
+
+#ifdef CONFIG_KM_MVMBUS
+	mvcpss_init_module(mvmbusdrv_init, "MBUS", &en_func_mbus);
+	mbus = en_func_mbus;
+#endif
+
+#ifdef CONFIG_KM_MVETH
+	mvcpss_init_module(mvppnd_init, "ETH", &en_func_eth);
+	pci |= en_func_eth;
+#endif
+
+#ifdef CONFIG_KM_MVINT
+	if (!pci && !mbus)
+		pr_warn("%s: INT driver with no PCI or MBUS\n", MODULE_NAME);
+
+	mvcpss_init_module(mvintdrv_init, "INT", &en_func_int);
+#endif
+
+	/* We are okay regarless of the status of the above */
+	return 0;
+}
+
+static void mvcpss_exit(void)
+{
+#ifdef CONFIG_KM_MVINT
+	mvcpss_exit_module(mvintdrv_exit, "INT", en_func_int);
+#endif
+
+#ifdef CONFIG_KM_MVETH
+	mvcpss_exit_module(mvppnd_exit, "ETH", en_func_eth);
+#endif
+
+#ifdef CONFIG_KM_MVMBUS
+	mvcpss_exit_module(mvmbusdrv_exit, "MBUS", en_func_mbus);
+#endif
+
+#ifdef CONFIG_KM_MVDMA
+	mvcpss_exit_module(mvdmadrv_exit, "DMA", en_func_dma);
+#endif
+
+#ifdef CONFIG_KM_MVDMA2
+	mvcpss_exit_module(mvdma2_exit, "DMA2", en_func_dma2);
+#endif
+
+#ifdef CONFIG_KM_MVPCI
+	mvcpss_exit_module(mvpci_exit, "PCI", en_func_pci);
+#endif
+}
+
+module_init(mvcpss_init);
+module_exit(mvcpss_exit);
+
+MODULE_AUTHOR("Yuval Shaia <yshaia@marvell.com>");
+MODULE_DESCRIPTION("Marvell's CPSS kernel module");
+MODULE_VERSION(CPSS_STREAM_NAME_CNS);
+MODULE_INFO(srcversion, GIT_HASH);
+MODULE_INFO(srcversion, BUILD_SOURCE);
+MODULE_LICENSE("Dual BSD/GPL");

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) Marvell International Ltd. and its affiliates
+ *
+ * This software file (the "File") is owned and distributed by Marvell
+ * International Ltd. and/or its affiliates ("Marvell") under the following
+ * alternative licensing terms.  Once you have made an election to distribute
+ * the file under one of the following license alternatives, please (i) delete
+ * this introductory statement regarding license alternatives, (ii) delete the
+ * two license alternatives that you have not elected to use and (iii) preserve
+ * the Marvell copyright notice above.
+ *
+ *******************************************************************************
+ * Marvell GPL License Option
+
+ * If you received this File from Marvell, you may opt to use, redistribute
+ * and/or modify this File in accordance with the terms and conditions of the
+ * General Public License Version 2, June 1991 (the "GPL License"), a copy of
+ * which is available along with the File in the license.txt file or by writing
+ * to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 or on the worldwide web at http://www.gnu.org/licenses/gpl.txt.
+ *
+ * THE FILE IS DISTRIBUTED AS-IS, WITHOUT WARRANTY OF ANY KIND, AND THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE ARE
+ * EXPRESSLY DISCLAIMED.  The GPL License provides additional details about this
+ * warranty disclaimer.
+*/
+
+/*
+ * mvpci.c
+ *
+ * DESCRIPTION:
+ *	A simple PCI driver that merely exposes interface to CPSS to enable and
+ *	disable PCI devices.
+ *	Usage:
+ *		enable:
+ *			echo -n "pci-vendor-id pci-device-id" >
+ *				/sys/bus/pci/drivers/mvpci/new_id
+ *		disable:
+ *			echo -n "pci-vendor-id pci-device-id" >
+ *				/sys/bus/pci/drivers/mvpci/remove_id
+ *
+ */
+
+#define MV_DRV_NAME "mvpci"
+
+#include <linux/pci.h>
+
+static int mvpcidrv_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+{
+	int rc;
+
+	dev_info(&pdev->dev, "Probing to PCI device\n");
+
+	rc = pci_enable_device(pdev);
+	if (rc) {
+		dev_err(&pdev->dev, "Fail to enable PCI device, aborting.\n");
+		rc = -ENOMEM;
+	}
+
+	return rc;
+}
+
+static void mvpcidrv_remove(struct pci_dev *pdev)
+{
+	dev_info(&pdev->dev, "Unprobing from PCI device\n");
+
+	pci_disable_device(pdev);
+}
+
+static struct pci_driver mvpcidrv_pci_driver = {
+	.name		= MV_DRV_NAME,
+	.probe		= mvpcidrv_probe,
+	.remove		= mvpcidrv_remove,
+	.driver.pm	= NULL,
+};
+
+void mvpci_exit(void)
+{
+	pci_unregister_driver(&mvpcidrv_pci_driver);
+}
+
+int mvpci_init(void)
+{
+	int rc;
+
+	rc = pci_register_driver(&mvpcidrv_pci_driver);
+	if (rc) {
+		pr_err("%s: Fail to register PCI driver\n", MV_DRV_NAME);
+		return rc;
+	}
+
+	return 0;
+}

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/srcversion.h
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/srcversion.h
@@ -1,0 +1,2 @@
+#define BUILD_SOURCE "pnaregundi@cpss-pnaregundi:/local/store/xps_wb/sai_cpss/cpss"
+#define GIT_HASH "N/A"

--- a/platform/arm64/7020/etc/modules-load.d/marvell.conf
+++ b/platform/arm64/7020/etc/modules-load.d/marvell.conf
@@ -1,3 +1,3 @@
 eeprom
-mvIntDrv
+mvcpss
 psample

--- a/platform/arm64/ac5x/etc/modules-load.d/marvell.conf
+++ b/platform/arm64/ac5x/etc/modules-load.d/marvell.conf
@@ -1,4 +1,3 @@
 eeprom
-mvMbusDrv
-mvIntDrv
+mvcpss
 psample


### PR DESCRIPTION
This driver upgrade brings unified driver changes. This update unifies the driver mentioned below. Output kernel module is named as mvcpss.ko.

Config option for compiling various cpss drivers:
CONFIG_KM_MVPCI/CONFIG_KM_MVMBUS - Depending on pci vs mbus for connecting to cpu.
CONFIG_KM_MVINT - Interrupt driver
CONFIG_KM_MVETH - Ethernet driver for control path packets handling
CONFIG_KM_MVDMA2/CONFIG_KM_MVDMA - SDMA memory allocation drivers, alternativity we can use kernel homepages.

Additionally mvSai.ko is SAI specific kernel driver for netdev packet handling.