### PR TITLE
[arm64] msai utility to print SAI/SDK Version.

### DIFF
--- a/platform/arm64/913x/usr/local/bin/msai
+++ b/platform/arm64/913x/usr/local/bin/msai
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+###########################################################################
+# /usr/bin/msai
+#
+# A convenient wrapper to print the Marvell SAI Info.
+###########################################################################
+banner()
+{
+  echo "+------------------------------------------+"
+  printf "|`tput bold` %-40s `tput sgr0`|\n" "$@"
+  echo "+------------------------------------------+"
+}
+banner "Marvell SAI Version"
+docker exec syncd mrvlcmd -c "dbg sai-dump call saiDumpBuildInfo" | grep -v end | grep -v "Console" 
+banner "Marvell SDK Version"
+docker exec syncd mrvlcmd -c "show version" | grep -v end | grep -v "Console"
+

--- a/platform/arm64/ac5x/usr/local/bin/msai
+++ b/platform/arm64/ac5x/usr/local/bin/msai
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+###########################################################################
+# /usr/bin/msai
+#
+# A convenient wrapper to print the Marvell SAI Info.
+###########################################################################
+banner()
+{
+  echo "+------------------------------------------+"
+  printf "|`tput bold` %-40s `tput sgr0`|\n" "$@"
+  echo "+------------------------------------------+"
+}
+banner "Marvell SAI Version"
+docker exec syncd mrvlcmd -c "dbg sai-dump call saiDumpBuildInfo" | grep -v end | grep -v "Console" 
+banner "Marvell SDK Version"
+docker exec syncd mrvlcmd -c "show version" | grep -v end | grep -v "Console"
+


### PR DESCRIPTION
Added utility script to print marvell prestera SAI and SDK build version.
```
+------------------------------------------+
| Marvell SAI Version                      |
+------------------------------------------+

 MRVL_SAI_BUILDUSER=rpennadamram
 MRVL_SAI_BUILDDIR=/cpss/users/rpennadamram/dev/code/sai_cpss/build
 MRVL_SAI_BUILDDATE=Sat Sep 30 08:51:44 IST 2023
 MRVL_SAI_BUILDHOST=cpss-rpennadamram
 MRVL_SAI_BUILD_VERSION=P2:0:1
 OCP_SAI_VERSION=1.12.0

+------------------------------------------+
| Marvell SDK Version                      |
+------------------------------------------+

CPSS version:  4.3.7.014
DxCh version:  CPSS 4.3.7
Build type:    Linux Standalone
System type:   32 bit Operating System
Enabler type:  appDemo
```