### PR TITLE
fix(ena/drv): handle last irq disregarding to sl-state

### DIFF
--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -215,13 +215,14 @@ static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 
 	BUG_ON(!sl);
 
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		atomic_dec(&sl->depth);
+	/* handle last interrupt after process termination
+	 * disregarding to (sl->state==IRQ_SLOT_STATE_ALLOCATED)
+	 */
+	atomic_dec(&sl->depth);
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		tasklet_hi_schedule((struct tasklet_struct *)tl);
+	tasklet_hi_schedule((struct tasklet_struct *)tl);
 
 	return IRQ_HANDLED;
 }
@@ -541,7 +542,7 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 {
 	struct interrupt_slot *sl;
 	unsigned int irq = -1;
-	char cmdBuf[6];
+	char cmdBuf[6] = {0};
 	int slot;
 
 	/* Write 2 bytes:

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -215,14 +215,13 @@ static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 
 	BUG_ON(!sl);
 
-	/* handle last interrupt after process termination
-	 * disregarding to (sl->state==IRQ_SLOT_STATE_ALLOCATED)
-	 */
-	atomic_dec(&sl->depth);
+	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
+		atomic_dec(&sl->depth);
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
-	tasklet_hi_schedule((struct tasklet_struct *)tl);
+	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
+		tasklet_hi_schedule((struct tasklet_struct *)tl);
 
 	return IRQ_HANDLED;
 }

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -215,13 +215,14 @@ static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 
 	BUG_ON(!sl);
 
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		atomic_dec(&sl->depth);
+	/* handle last interrupt after process termination
+	 * disregarding to (sl->state==IRQ_SLOT_STATE_ALLOCATED)
+	 */
+	atomic_dec(&sl->depth);
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		tasklet_hi_schedule((struct tasklet_struct *)tl);
+	tasklet_hi_schedule((struct tasklet_struct *)tl);
 
 	return IRQ_HANDLED;
 }

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -117,13 +117,14 @@ static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 
 	BUG_ON(!sl);
 
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		atomic_dec(&sl->depth);
+	/* handle last interrupt after process termination
+	 * disregarding to (sl->state==IRQ_SLOT_STATE_ALLOCATED)
+	 */
+	atomic_dec(&sl->depth);
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		tasklet_hi_schedule((struct tasklet_struct *)tl);
+	tasklet_hi_schedule((struct tasklet_struct *)tl);
 
 	return IRQ_HANDLED;
 }

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -117,14 +117,13 @@ static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 
 	BUG_ON(!sl);
 
-	/* handle last interrupt after process termination
-	 * disregarding to (sl->state==IRQ_SLOT_STATE_ALLOCATED)
-	 */
-	atomic_dec(&sl->depth);
+	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
+		atomic_dec(&sl->depth);
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
-	tasklet_hi_schedule((struct tasklet_struct *)tl);
+	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
+		tasklet_hi_schedule((struct tasklet_struct *)tl);
 
 	return IRQ_HANDLED;
 }

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -117,13 +117,14 @@ static irqreturn_t prestera_tl_ISR(int irq, void *tl)
 
 	BUG_ON(!sl);
 
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		atomic_dec(&sl->depth);
+	/* handle last interrupt after process termination
+	 * disregarding to (sl->state==IRQ_SLOT_STATE_ALLOCATED)
+	 */
+	atomic_dec(&sl->depth);
 	/* Disable the interrupt vector */
 	disable_irq_nosync(irq);
 	/* Enqueue the PP task BH in the tasklet */
-	if (unlikely((sl->state == IRQ_SLOT_STATE_ALLOCATED))) /* handle last interrupt after process termination */
-		tasklet_hi_schedule((struct tasklet_struct *)tl);
+	tasklet_hi_schedule((struct tasklet_struct *)tl);
 
 	return IRQ_HANDLED;
 }
@@ -413,7 +414,7 @@ static ssize_t mvIntDrv_write(struct file *f, const char *buf, size_t siz, loff_
 {
 	struct interrupt_slot *sl;
 	unsigned int irq = -1;
-	char cmdBuf[6];
+	char cmdBuf[6] = {0};
 	int slot;
 
 	/* Write 2 bytes:


### PR DESCRIPTION
  fix(ena/drv): handle last irq disregarding to sl-state
  
  Fix 656aeef9cc "free irqs on module exit":
    Free reallocatable irqs on exit to prevent kernel WARN on reboot.
  
  PROBLEM:
  BM test ".prvTgfFdbTriggeredDeleteWithMessages" failed with
  waiting forever for event
  = : start waiting appDemo to finish processing the AA from the AUQ =
  = : still [12288] massages in the AUQ) =======
  
  FIX:
  Restore prestera_tl_ISR() -
  always tasklet-handle last interrupt after process termination
  disregarding to the (sl->state==IRQ_SLOT_STATE_ALLOCATED) or not.