### PR TITLE
driver mvcpss.ko source adjust for Kernel-6.12

### DIFF
--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
@@ -208,6 +208,9 @@ disclaimer.
 #define MV_DMA_ALLOC_FLAGS GFP_DMA32 | GFP_NOFS
 #define MAX_DMA_ALLOC_RETRIES   10
 
+void mvdmadrv_exit(void);
+int mvdmadrv_init(void);
+
 /* Character device context */
 static struct mvchrdev_ctx *chrdrv_ctx;
 /* Did we successfully registered as platform driver? zero means yes */
@@ -1030,13 +1033,19 @@ static int mvdmadrv_pdriver_probe(struct platform_device *pdev)
 	return 0;
 };
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
+static void mvdmadrv_pdriver_remove(struct platform_device *pdev)
+#else
 static int mvdmadrv_pdriver_remove(struct platform_device *pdev)
+#endif
 {
 	BUG_ON(!platdrv_registered);
 
 	of_reserved_mem_device_release(&pdev->dev);
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
 	return 0;
+#endif
 }
 
 static const struct of_device_id mvdmadrv_of_match_ids[] = {
@@ -1083,6 +1092,7 @@ void mvdmadrv_exit(void)
 		kfree(shared_dmaBlock);
 	}
 }
+
 int mvdmadrv_init(void)
 {
 #ifdef SUPPORT_PLATFORM_DEVICE

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
@@ -163,6 +163,9 @@ struct list_head opened_files; /* List of file_desc (for debugfs) */
 /* debugfs dir and mmaps file */
 struct dentry *debugfs_dir, *debugfs_mmaps;
 
+void mvdma2_exit(void);
+int mvdma2_init(void);
+
 /* Add filep to opened_files */
 static void mvdma_add_open_file(struct file *file)
 {
@@ -693,13 +696,20 @@ static int mvdma_pdriver_probe(struct platform_device *pdev)
 	return 0;
 };
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
+static void mvdma_pdriver_remove(struct platform_device *pdev)
+#else
 static int mvdma_pdriver_remove(struct platform_device *pdev)
+#endif
 {
 	BUG_ON(!platform_dev_mappings);
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3,19,8))
 	of_reserved_mem_device_release(&pdev->dev);
 #endif
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
 	return 0;
+#endif
 }
 
 static const struct of_device_id mvdma_of_match_ids[] = {

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
@@ -160,6 +160,10 @@ MODULE_PARM_DESC(rx_counter_dump, "Counter, when exceeds print message");
 
 struct rx_context rx_ctx = {};
 
+int process_rx(struct net_device *ndev, unsigned char *data, int *sz,
+		int max_sz);
+int process_tx(struct net_device *ndev, struct sk_buff *skb);
+
 /**
 * @internal print_buf function
 * @endinternal

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -60,6 +60,10 @@ disclaimer.
 #include <linux/list.h>
 #include <linux/delay.h>
 
+void mvPresteraBh(unsigned long data);
+void mvintdrv_exit(void);
+int mvintdrv_init(void);
+
 /* Character device context */
 static struct mvchrdev_ctx *chrdrv_ctx;
 static struct semaphore mvint_pci_devs_sem;

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
@@ -66,6 +66,9 @@ static struct mvchrdev_ctx *chrdrv_ctx;
 
 int mvMbusDrvDevId = 0;
 
+void mvmbusdrv_exit(void);
+int mvmbusdrv_init(void);
+
 static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
 {
 	struct mv_resource_info res = {0};
@@ -91,7 +94,11 @@ static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
 		return -ENXIO;
 	}
 	/* VM_IO for I/O memory */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,6,0)
 	vma->vm_flags |= VM_IO;
+#else
+	vm_flags_set(vma, VM_IO);
+#endif
 	/* disable caching on mapped memory */
 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
 	vma->vm_pgoff = res.start >> PAGE_SHIFT;

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
@@ -45,6 +45,9 @@
 
 #include <linux/pci.h>
 
+void mvpci_exit(void);
+int mvpci_init(void);
+
 static int mvpcidrv_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 {
 	int rc;

--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
+++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
@@ -605,7 +605,11 @@ static int __init sai_init(void)
 
     major = err;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
     sai_class = class_create(THIS_MODULE, SAI_NAME);
+#else
+    sai_class = class_create(SAI_NAME);
+#endif
     if (IS_ERR(sai_class)) {
         err = PTR_ERR(sai_class);
         goto out_chrdev;

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
@@ -116,6 +116,9 @@ disclaimer.
 
 #define MV_DMA_ALLOC_FLAGS GFP_DMA32 | GFP_NOFS
 
+void mvdmadrv_exit(void);
+int mvdmadrv_init(void);
+
 /* Character device context */
 static struct mvchrdev_ctx *chrdrv_ctx;
 /* Did we successfully registered as platform driver? zero means yes */
@@ -446,13 +449,19 @@ static int mvdmadrv_pdriver_probe(struct platform_device *pdev)
 	return 0;
 };
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
+static void mvdmadrv_pdriver_remove(struct platform_device *pdev)
+#else
 static int mvdmadrv_pdriver_remove(struct platform_device *pdev)
+#endif
 {
 	BUG_ON(!platdrv_registered);
 
 	of_reserved_mem_device_release(&pdev->dev);
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
 	return 0;
+#endif
 }
 
 static const struct of_device_id mvdmadrv_of_match_ids[] = {
@@ -492,6 +501,7 @@ void mvdmadrv_exit(void)
 		kfree(shared_dmaBlock);
 	}
 }
+
 int mvdmadrv_init(void)
 {
 #ifdef SUPPORT_PLATFORM_DEVICE

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
@@ -164,6 +164,9 @@ struct list_head opened_files; /* List of file_desc (for debugfs) */
 /* debugfs dir and mmaps file */
 struct dentry *debugfs_dir, *debugfs_mmaps;
 
+void mvdma2_exit(void);
+int mvdma2_init(void);
+
 /* Add filep to opened_files */
 static void mvdma_add_open_file(struct file *file)
 {
@@ -777,13 +780,20 @@ static int mvdma_pdriver_probe(struct platform_device *pdev)
 	return 0;
 };
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
+static void mvdma_pdriver_remove(struct platform_device *pdev)
+#else
 static int mvdma_pdriver_remove(struct platform_device *pdev)
+#endif
 {
 	BUG_ON(!platform_dev_mappings);
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3,19,8))
 	of_reserved_mem_device_release(&pdev->dev);
 #endif
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
 	return 0;
+#endif
 }
 
 static const struct of_device_id mvdma_of_match_ids[] = {

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
@@ -416,6 +416,13 @@ struct device_private_data ac5p_private_data = {REG_ADDR_BASE_AC5P};
 struct device_private_data ac5x_private_data = {REG_ADDR_BASE_AC5X};
 struct device_private_data ac5_private_data = {REG_ADDR_BASE_AC5};
 
+int mvppnd_poll(struct napi_struct *napi, int budget);
+void mvppnd_free_wq(struct mvppnd_dev *ppdev);
+int mvppnd_open(struct net_device *dev);
+int mvppnd_stop(struct net_device *dev);
+int mvppnd_init(void);
+void mvppnd_exit(void);
+
 /*
  * netif_receive_skb_list() was only introduced in
  * kernel 4.19 . Make a naive implementation of
@@ -4229,7 +4236,11 @@ out:
 	return 0;
 };
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+static void mvppnd_pdriver_remove(struct platform_device *pdev)
+#else
 static int mvppnd_pdriver_remove(struct platform_device *pdev)
+#endif
 {
 	struct mvppnd_dev *ppdev;
 
@@ -4237,7 +4248,11 @@ static int mvppnd_pdriver_remove(struct platform_device *pdev)
 
 	ppdev = (struct mvppnd_dev *)dev_get_drvdata(&pdev->dev);
 	if (!ppdev)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
 		return 0;
+#else
+		return;
+#endif
 
 	ppdev->going_down = true;
 
@@ -4252,7 +4267,9 @@ static int mvppnd_pdriver_remove(struct platform_device *pdev)
 
 	dev_info(&pdev->dev, "Detached from device\n");
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
 	return 0;
+#endif
 }
 
 static const struct of_device_id mvppnd_of_match_ids[] = {

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
@@ -160,6 +160,10 @@ MODULE_PARM_DESC(rx_counter_dump, "Counter, when exceeds print message");
 
 struct rx_context rx_ctx = {};
 
+int process_rx(struct net_device *ndev, unsigned char *data, int *sz,
+		int max_sz);
+int process_tx(struct net_device *ndev, struct sk_buff *skb);
+
 /**
 * @internal print_buf function
 * @endinternal

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
@@ -58,6 +58,10 @@ disclaimer.
 #include <linux/irq.h>
 #include <linux/list.h>
 
+void mvPresteraBh(unsigned long data);
+void mvintdrv_exit(void);
+int mvintdrv_init(void);
+
 /* Character device context */
 static struct mvchrdev_ctx *chrdrv_ctx;
 

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
@@ -66,6 +66,9 @@ static struct mvchrdev_ctx *chrdrv_ctx;
 
 int mvMbusDrvDevId = 0;
 
+void mvmbusdrv_exit(void);
+int mvmbusdrv_init(void);
+
 static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
 {
 	struct mv_resource_info res = {0};
@@ -91,7 +94,11 @@ static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
 		return -ENXIO;
 	}
 	/* VM_IO for I/O memory */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,6,0)
 	vma->vm_flags |= VM_IO;
+#else
+	vm_flags_set(vma, VM_IO);
+#endif
 	/* disable caching on mapped memory */
 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
 	vma->vm_pgoff = res.start >> PAGE_SHIFT;

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
@@ -45,6 +45,9 @@
 
 #include <linux/pci.h>
 
+void mvpci_exit(void);
+int mvpci_init(void);
+
 static int mvpcidrv_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 {
 	int rc;

--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
+++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
@@ -657,7 +657,11 @@ static int __init sai_init(void)
 
     major = err;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
     sai_class = class_create(THIS_MODULE, SAI_NAME);
+#else
+    sai_class = class_create(SAI_NAME);
+#endif
     if (IS_ERR(sai_class)) {
         err = PTR_ERR(sai_class);
         goto out_chrdev;


### PR DESCRIPTION
Fix/adjust armhf and generic linuxNoKernelModule/drivers for compilation with k6.12.

The changes are fully backward compatible with previous k6.1