### PR TITLE
sonic-ext.target wrapper for sonic.target

### DIFF
--- a/debian/mrvlprestera.install.template
+++ b/debian/mrvlprestera.install.template
@@ -1,2 +1,3 @@
+platform/common/* /
 platform/ARCH/common/boot/*.dtb /boot
 platform/ARCH/common/usr/local/bin/* /usr/local/bin

--- a/debian/rules
+++ b/debian/rules
@@ -24,6 +24,8 @@ override_dh_auto_build:
 	@if [ "$(CONFIGURED_ARCH)" = "amd64" ]; then \
 		echo "platform/$(CONFIGURED_ARCH)/common/usr/local/bin/* /usr/local/bin" > \
 		    ${MOD_SRC_DIR}/debian/mrvlprestera.install; \
+		echo "platform/common/* /" >> \
+		    ${MOD_SRC_DIR}/debian/mrvlprestera.install; \
 	else \
 		sed "s/ARCH/${CONFIGURED_ARCH}/g" \
 		    ${MOD_SRC_DIR}/debian/mrvlprestera.install.template \

--- a/platform/common/etc/systemd/system/multi-user.target.wants/sonic-ext.target
+++ b/platform/common/etc/systemd/system/multi-user.target.wants/sonic-ext.target
@@ -1,0 +1,1 @@
+/lib/systemd/system/sonic-ext.target

--- a/platform/common/usr/lib/systemd/system/sonic-ext.target
+++ b/platform/common/usr/lib/systemd/system/sonic-ext.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=SONiC extended target starting sonic.target after pre.service
+Requires=sonic-pre.service
+After=sonic-pre.service
+Wants=sonic.target

--- a/platform/common/usr/lib/systemd/system/sonic-pre.service
+++ b/platform/common/usr/lib/systemd/system/sonic-pre.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SONiC pre-start service
+Before=sonic.target
+ConditionPathExists=/usr/local/bin/sonic-pre.sh
+DefaultDependencies=no
+After=local-fs.target
+Requires=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sonic-pre.sh
+RemainAfterExit=yes
+TimeoutStartSec=0
+
+[Install]
+WantedBy=sonic-ext.target
+

--- a/platform/common/usr/local/bin/sonic-pre.sh
+++ b/platform/common/usr/local/bin/sonic-pre.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+MACHINE=$(uname -m)
+
+if [ -f /usr/local/bin/sonic_firstboot ]; then
+    rm -f /usr/local/bin/sonic_firstboot
+    case $MACHINE in
+        armv7l)
+            DELAY=30
+            ;;
+        aarch64|x86_64)
+            DELAY=2
+            ;;
+        *)
+            DELAY=0
+            ;;
+    esac
+else
+    case $MACHINE in
+        armv7l)
+            DELAY=20
+            ;;
+        aarch64|x86_64)
+            DELAY=0
+            ;;
+        *)
+            DELAY=0
+            ;;
+    esac
+fi
+
+echo "sonic-pre start with delay $DELAY sec" > /dev/kmsg
+if [ "$DELAY" -eq 0 ]; then exit 0; fi
+sleep $DELAY
+echo "sonic-pre end. Start sonic" > /dev/kmsg
+


### PR DESCRIPTION
Create and enable sonic-ext.target wrapper acrivated on boot instead of regular sonic.target and applying the sonic-pre.service with "hook" sonic-ext.sh before activating for sonic.target.

This wrapper does not impacts the SONiC commands having sonic.target start/stop/restart inside, but the bootup only.

On devices slow CPU (armhf) this permits to "split/delay" between Debian bootup and SONiC.