### PR TITLE
sonic.target no-install overload for sonic-ext.target

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,6 +31,8 @@ override_dh_auto_build:
 		    ${MOD_SRC_DIR}/debian/mrvlprestera.install.template \
 		    > ${MOD_SRC_DIR}/debian/mrvlprestera.install; \
 	fi
+	cp -f ${MOD_SRC_DIR}/platform/files-overload/sonic.target \
+	      ${MOD_SRC_DIR}/../../../files/build_templates/sonic.target
 
 override_dh_auto_test:
 	# No tests to run

--- a/platform/files-overload/sonic.target
+++ b/platform/files-overload/sonic.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=SONiC services target.
+
+#[Install]
+#WantedBy=multi-user.target


### PR DESCRIPTION
Overload an original source-file files/build_templates/sonic.target with Disabled [Install] section.
Needed for correct/designed sonic-ext.target work.