### PR TITLE
sonic.target and pcie check - 3patches

### DIFF
--- a/debian/mrvlprestera.install.template
+++ b/debian/mrvlprestera.install.template
@@ -1,2 +1,3 @@
+platform/common/* /
 platform/ARCH/common/boot/*.dtb /boot
 platform/ARCH/common/usr/local/bin/* /usr/local/bin

--- a/debian/rules
+++ b/debian/rules
@@ -31,6 +31,8 @@ override_dh_auto_build:
 		    ${MOD_SRC_DIR}/debian/mrvlprestera.install.template \
 		    > ${MOD_SRC_DIR}/debian/mrvlprestera.install; \
 	fi
+	cp -f ${MOD_SRC_DIR}/platform/files-overload/sonic.target \
+	      ${MOD_SRC_DIR}/../../../files/build_templates/sonic.target
 
 override_dh_auto_test:
 	# No tests to run

--- a/debian/rules
+++ b/debian/rules
@@ -24,6 +24,8 @@ override_dh_auto_build:
 	@if [ "$(CONFIGURED_ARCH)" = "amd64" ]; then \
 		echo "platform/$(CONFIGURED_ARCH)/common/usr/local/bin/* /usr/local/bin" > \
 		    ${MOD_SRC_DIR}/debian/mrvlprestera.install; \
+		echo "platform/common/* /" >> \
+		    ${MOD_SRC_DIR}/debian/mrvlprestera.install; \
 	else \
 		sed "s/ARCH/${CONFIGURED_ARCH}/g" \
 		    ${MOD_SRC_DIR}/debian/mrvlprestera.install.template \

--- a/platform/arm64/common/etc/systemd/system/multi-user.target.wants/mrvl-pcie-ep-check.service
+++ b/platform/arm64/common/etc/systemd/system/multi-user.target.wants/mrvl-pcie-ep-check.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/mrvl-pcie-ep-check.service

--- a/platform/arm64/common/usr/lib/systemd/system/mrvl-pcie-ep-check.service
+++ b/platform/arm64/common/usr/lib/systemd/system/mrvl-pcie-ep-check.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Marvell PCIe-EP check
+DefaultDependencies=no
+After=local-fs.target
+Wants=local-fs.target
+Before=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/mrvl-pcie-ep-check.sh
+
+[Install]
+WantedBy=sysinit.target
+#WantedBy=multi-user.target
+

--- a/platform/arm64/common/usr/local/bin/mrvl-pcie-ep-check.sh
+++ b/platform/arm64/common/usr/local/bin/mrvl-pcie-ep-check.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# mrvl-check-pcie-ep.sh
+#  Check Marvell-End-Point presence, reboot if not found
+#
+# Run on Init context, service-safe, logs via /dev/kmsg
+
+# Conditional: only for CN9131-DB-Comexpress
+if ! grep -iq "CN9131-DB-Comexpress" /proc/device-tree/model 2>/dev/null; then
+    # Not the target model -> exit clean
+    exit 0
+fi
+
+# EVENT_FILE is persistent marker file preventing loop on persistent miss
+EVENT_FILE="/var/lib/mrvl-pcie-ep-reboot-req"
+STAT_PASS="/var/lib/mrvl-pcie-ep-reboot.pass"
+STAT_FAIL="/var/lib/mrvl-pcie-ep-reboot.fail"
+
+# Find PCIe endpoint (Marvell vendor, not root-port)
+EP=""
+for d in /sys/bus/pci/devices/*; do
+    vend=$(cat "$d/vendor" 2>/dev/null)
+    cls=$(cat "$d/class"  2>/dev/null)
+
+    case "$vend:$cls" in
+        0x11ab:0x0604??) ;;      # skip bridges/root-ports
+        0x11ab:0x??????) EP="$d"; break ;; # endpoint 020000 found
+    esac
+done
+
+# Handle PCIe endpoint presence
+if [ ! -z "$EP" ]; then
+    # PCIe OK -> remove any previous marker
+    [ -f "$EVENT_FILE" ] && rm -f "$EVENT_FILE"
+    CNTR_PASS=$(cat "$STAT_PASS" 2>/dev/null)
+    CNTR_PASS=$((CNTR_PASS + 1))
+    echo "$CNTR_PASS" > "$STAT_PASS"
+    exit 0
+fi
+
+CNTR_FLT=$(cat "$STAT_FAIL" 2>/dev/null)
+CNTR_FLT=$((CNTR_FLT + 1))
+echo "$CNTR_FLT" > "$STAT_FAIL"
+
+echo "ERROR: Marvell PCIe endpoint missing" >/dev/kmsg
+echo "=================================================" >/dev/console
+echo "ERROR: Marvell PCIe endpoint missing"              >/dev/console
+echo "=================================================" >/dev/console
+if [ ! -f "$EVENT_FILE" ]; then
+    touch "$EVENT_FILE"
+    sync
+    reboot
+fi
+exit 0

--- a/platform/common/etc/systemd/system/multi-user.target.wants/sonic-ext.target
+++ b/platform/common/etc/systemd/system/multi-user.target.wants/sonic-ext.target
@@ -1,0 +1,1 @@
+/lib/systemd/system/sonic-ext.target

--- a/platform/common/usr/lib/systemd/system/sonic-ext.target
+++ b/platform/common/usr/lib/systemd/system/sonic-ext.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=SONiC extended target starting sonic.target after pre.service
+Requires=sonic-pre.service
+After=sonic-pre.service
+Wants=sonic.target

--- a/platform/common/usr/lib/systemd/system/sonic-pre.service
+++ b/platform/common/usr/lib/systemd/system/sonic-pre.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SONiC pre-start service
+Before=sonic.target
+ConditionPathExists=/usr/local/bin/sonic-pre.sh
+DefaultDependencies=no
+After=local-fs.target
+Requires=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sonic-pre.sh
+RemainAfterExit=yes
+TimeoutStartSec=0
+
+[Install]
+WantedBy=sonic-ext.target
+

--- a/platform/common/usr/local/bin/sonic-pre.sh
+++ b/platform/common/usr/local/bin/sonic-pre.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+MACHINE=$(uname -m)
+
+if [ -f /usr/local/bin/sonic_firstboot ]; then
+    rm -f /usr/local/bin/sonic_firstboot
+    case $MACHINE in
+        armv7l)
+            DELAY=30
+            ;;
+        aarch64|x86_64)
+            DELAY=2
+            ;;
+        *)
+            DELAY=0
+            ;;
+    esac
+else
+    case $MACHINE in
+        armv7l)
+            DELAY=20
+            ;;
+        aarch64|x86_64)
+            DELAY=0
+            ;;
+        *)
+            DELAY=0
+            ;;
+    esac
+fi
+
+echo "sonic-pre start with delay $DELAY sec" > /dev/kmsg
+if [ "$DELAY" -eq 0 ]; then exit 0; fi
+sleep $DELAY
+echo "sonic-pre end. Start sonic" > /dev/kmsg
+

--- a/platform/files-overload/sonic.target
+++ b/platform/files-overload/sonic.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=SONiC services target.
+
+#[Install]
+#WantedBy=multi-user.target


### PR DESCRIPTION
0060-sonic-ext.target-wrapper-for-sonic.target.patch
0061-sonic.target-no-install-oveload-for-sonic-ext.target.patch
0104-platform-X-arm64-mrvl-pcie-ep-check-reboot-on-EP-miss.patch
